### PR TITLE
implement wrapped barrier

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -157,6 +157,10 @@ func (n *Namespace) Clone() *Namespace {
 	}
 }
 
+func (n *Namespace) IsRoot() bool {
+	return n.ID == RootNamespaceID
+}
+
 // ContextWithNamespace adds the given namespace to the given context
 func ContextWithNamespace(ctx context.Context, ns *Namespace) context.Context {
 	return context.WithValue(ctx, contextNamespace, ns)

--- a/vault/barrier_wrapping.go
+++ b/vault/barrier_wrapping.go
@@ -1,0 +1,70 @@
+package vault
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+var _ physical.Backend = (*ForwardingBackend)(nil)
+
+// ForwardingBackend implements physical.Backend on top of a logical.Storage
+type ForwardingBackend struct {
+	target logical.Storage
+}
+
+func NewForwardingBackend(wrapped logical.Storage) *ForwardingBackend {
+	return &ForwardingBackend{
+		target: wrapped,
+	}
+}
+
+// NewNamespaceBarrier constructs a new wrapped Barrier for the given namespace.
+// The passed parent SecurityBarrier must be the closest parent namespace barrier.
+func NewNamespaceBarrier(parent logical.Storage, ns *namespace.Namespace) (SecurityBarrier, error) {
+	if ns.IsRoot() {
+		return nil, errors.New("can't construct namespace barrier for root namespace")
+	}
+	metaPrefix := namespaceBarrierPrefix + ns.UUID + "/"
+	return NewAESGCMBarrier(NewForwardingBackend(parent), metaPrefix)
+}
+
+func (f *ForwardingBackend) Delete(ctx context.Context, path string) error {
+	return f.target.Delete(ctx, path)
+}
+
+func (f *ForwardingBackend) Get(ctx context.Context, path string) (*physical.Entry, error) {
+	se, err := f.target.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if se == nil {
+		return nil, nil
+	}
+	pe := physical.Entry{
+		Key:      se.Key,
+		Value:    se.Value,
+		SealWrap: se.SealWrap,
+	}
+	return &pe, nil
+}
+
+func (f *ForwardingBackend) Put(ctx context.Context, pe *physical.Entry) error {
+	se := logical.StorageEntry{
+		Key:      pe.Key,
+		Value:    pe.Value,
+		SealWrap: pe.SealWrap,
+	}
+	return f.target.Put(ctx, &se)
+}
+
+func (f *ForwardingBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return f.target.List(ctx, prefix)
+}
+
+func (f *ForwardingBackend) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return f.target.ListPage(ctx, prefix, after, limit)
+}

--- a/vault/barrier_wrapping_test.go
+++ b/vault/barrier_wrapping_test.go
@@ -1,0 +1,49 @@
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrappedBarrier_Basic(t *testing.T) {
+	_, b, _ := mockBarrier(t)
+	fb := NewForwardingBackend(b)
+	wb, err := NewAESGCMBarrier(fb, "test/")
+	require.NoError(t, err)
+
+	testBarrier(t, wb)
+}
+
+func TestWrappedBarrier_DoubleEncryption(t *testing.T) {
+	_, b, _ := mockBarrier(t)
+	fb := NewForwardingBackend(b)
+	wb, err := NewAESGCMBarrier(fb, "test/")
+	require.NoError(t, err)
+	err, _, _ = testInitAndUnseal(t, wb)
+	require.NoError(t, err)
+
+	seIn := logical.StorageEntry{Key: "testkey1", Value: []byte("testvalue1")}
+	err = wb.Put(context.TODO(), &seIn)
+	require.NoError(t, err)
+
+	seOut, err := b.Get(context.TODO(), seIn.Key)
+	require.NoError(t, err)
+	require.Equal(t, seIn.Key, seOut.Key)
+	require.NotEqual(t, seIn.Value, seOut.Value)
+
+	pt, err := wb.Decrypt(context.TODO(), seIn.Key, seOut.Value)
+	require.NoError(t, err)
+	require.Equal(t, seIn.Value, pt)
+}
+
+func TestWrappedBarrier_Rotate(t *testing.T) {
+	_, b, _ := mockBarrier(t)
+	fb := NewForwardingBackend(b)
+	wb, err := NewAESGCMBarrier(fb, "test/")
+	require.NoError(t, err)
+
+	testBarrier_Rotate(t, wb)
+}


### PR DESCRIPTION
Implements a wrapper that allows logical.Storage to act as physical.Backend. This allows wrapping a AESGCMBarrier in another AESGCMBarrier to double encrypt the data. Each sealable namespace will add another wrapping layer.

Note that it does not restrict the readable or writable keys like a BarrierView, but allows access to the full storage. It will just encrypt the data multiple times. It can still be combined with e.g. NamespaceView to restrict the view to a certain prefix.