### PR TITLE
POC - create sealed namespace

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -379,6 +379,9 @@ type Core struct {
 	// namespace Store is used to manage namespaces
 	namespaceStore *NamespaceStore
 
+	// sealManager is used to manage seals per namespace
+	sealManager *SealManager
+
 	// identityStore is used to manage client entities
 	identityStore *IdentityStore
 
@@ -2267,6 +2270,9 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 		return err
 	}
 	if err := c.setupNamespaceStore(ctx); err != nil {
+		return err
+	}
+	if err := c.setupSealManager(ctx); err != nil {
 		return err
 	}
 	if err := c.loadMounts(ctx); err != nil {

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
@@ -221,7 +222,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 			return nil, err
 		}
 	} else {
-		config, err = c.seal.BarrierConfig(ctx)
+		config, err = c.seal.BarrierConfig(ctx, namespace.RootNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -570,7 +570,7 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 		// everything is sane. If we have no sanity in the barrier, we actually
 		// seal, as there's little we can do.
 		{
-			c.seal.SetBarrierConfig(activeCtx, nil)
+			c.seal.SetBarrierConfig(activeCtx, nil, namespace.RootNamespace)
 			if c.seal.RecoveryKeySupported() {
 				c.seal.SetRecoveryConfig(activeCtx, nil)
 			}
@@ -956,8 +956,8 @@ func (c *Core) reloadRootKey(ctx context.Context) error {
 }
 
 func (c *Core) reloadShamirKey(ctx context.Context) error {
-	_ = c.seal.SetBarrierConfig(ctx, nil)
-	if cfg, _ := c.seal.BarrierConfig(ctx); cfg == nil {
+	_ = c.seal.SetBarrierConfig(ctx, nil, namespace.RootNamespace)
+	if cfg, _ := c.seal.BarrierConfig(ctx, namespace.RootNamespace); cfg == nil {
 		return nil
 	}
 	var shamirKey []byte

--- a/vault/init.go
+++ b/vault/init.go
@@ -250,7 +250,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		return nil, fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	barrierKey, barrierKeyShares, err := c.generateShares(barrierConfig)
+	barrierKey, deprecatedBarrierKeyShares, err := c.generateShares(barrierConfig)
 	if err != nil {
 		c.logger.Error("error generating shares", "error", err)
 		return nil, err
@@ -329,7 +329,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	default:
 		// We don't support initializing an old-style Shamir seal anymore, so
 		// this case is only reachable by tests.
-		results.SecretShares = barrierKeyShares
+		results.SecretShares = deprecatedBarrierKeyShares
 	}
 
 	// Perform initial setup

--- a/vault/init.go
+++ b/vault/init.go
@@ -105,7 +105,7 @@ func (c *Core) InitializedLocally(ctx context.Context) (bool, error) {
 	}
 
 	// Verify the seal configuration
-	sealConf, err := c.seal.BarrierConfig(ctx)
+	sealConf, err := c.seal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		return false, err
 	}
@@ -292,7 +292,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		}
 	}()
 
-	err = c.seal.SetBarrierConfig(ctx, barrierConfig)
+	err = c.seal.SetBarrierConfig(ctx, barrierConfig, namespace.RootNamespace)
 	if err != nil {
 		c.logger.Error("failed to save barrier configuration", "error", err)
 		return nil, fmt.Errorf("barrier configuration saving failed: %w", err)

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -65,7 +66,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err := c.seal.BarrierConfig(context.Background())
+	outConf, err := c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -121,7 +122,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err = c.seal.BarrierConfig(context.Background())
+	outConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -162,7 +163,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err = c2.seal.BarrierConfig(context.Background())
+	outConf, err = c2.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -378,7 +378,7 @@ func (b *SystemBackend) handleRaftBootstrapChallengeWrite() framework.OperationF
 			return nil, err
 		}
 
-		sealConfig, err := b.Core.seal.BarrierConfig(ctx)
+		sealConfig, err := b.Core.seal.BarrierConfig(ctx, namespace.RootNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -515,7 +515,7 @@ func (ns *NamespaceStore) getNamespaceByPathLocked(ctx context.Context, path str
 // ModifyNamespace is used to perform modifications to a namespace while
 // holding a write lock to prevent other changes to namespaces from occurring
 // at the same time.
-func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, sealConfigs []*SealConfig, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, error) {
+func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, error) {
 	defer metrics.MeasureSince([]string{"namespace", "modify_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
@@ -559,13 +559,6 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 	// setNamespaceLocked will unlock ns.lock
 	if err := ns.setNamespaceLocked(ctx, entry); err != nil {
 		return nil, err
-	}
-
-	// TODO: adjust
-	if len(sealConfigs) > 0 {
-		if err := ns.core.sealManager.SetSeal(ctx, sealConfigs[0], entry.Clone()); err != nil {
-			return nil, err
-		}
 	}
 
 	return entry.Clone(), nil

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -928,7 +929,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 		// false.
 		if c.seal.BarrierType() == wrapping.WrapperTypeShamir && !c.isRaftHAOnly() {
 			c.raftInfo.Store(raftInfo)
-			if err := c.seal.SetBarrierConfig(ctx, raftInfo.leaderBarrierConfig); err != nil {
+			if err := c.seal.SetBarrierConfig(ctx, raftInfo.leaderBarrierConfig, namespace.RootNamespace); err != nil {
 				return err
 			}
 

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -213,7 +214,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	if recovery {
 		sealConf, err = c.seal.RecoveryConfig(context.Background())
 	} else {
-		sealConf, err = c.seal.BarrierConfig(context.Background())
+		sealConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	}
 	if err != nil {
 		t.Fatalf("seal config retrieval error: %v", err)
@@ -314,7 +315,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	if recovery {
 		sealConf, err = c.seal.RecoveryConfig(context.Background())
 	} else {
-		sealConf, err = c.seal.BarrierConfig(context.Background())
+		sealConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	}
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -15,6 +15,7 @@ import (
 
 	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 
@@ -227,9 +228,15 @@ func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig) 
 		return fmt.Errorf("failed to encode seal configuration: %w", err)
 	}
 
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve namespace from ctx: %w", err)
+	}
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+
 	// Store the seal configuration
 	pe := &physical.Entry{
-		Key:   barrierSealConfigPath,
+		Key:   view.Prefix(),
 		Value: buf,
 	}
 

--- a/vault/seal_access.go
+++ b/vault/seal_access.go
@@ -8,6 +8,7 @@ import (
 
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/vault/seal"
 )
 
@@ -31,7 +32,7 @@ func (s *SealAccess) BarrierType() wrapping.WrapperType {
 }
 
 func (s *SealAccess) BarrierConfig(ctx context.Context) (*SealConfig, error) {
-	return s.seal.BarrierConfig(ctx)
+	return s.seal.BarrierConfig(ctx, namespace.RootNamespace)
 }
 
 func (s *SealAccess) RecoveryKeySupported() bool {
@@ -48,7 +49,7 @@ func (s *SealAccess) VerifyRecoveryKey(ctx context.Context, key []byte) error {
 
 // TODO(SEALHA): This looks like it belongs in Seal instead, it only has two callers
 func (s *SealAccess) ClearCaches(ctx context.Context) {
-	s.seal.SetBarrierConfig(ctx, nil)
+	s.seal.SetBarrierConfig(ctx, nil, namespace.RootNamespace)
 	if s.RecoveryKeySupported() {
 		s.seal.SetRecoveryConfig(ctx, nil)
 	}

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -20,6 +20,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/seal"
 )
@@ -188,7 +189,7 @@ func (d *autoSeal) UpgradeKeys(ctx context.Context) error {
 	return nil
 }
 
-func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
+func (d *autoSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace) (*SealConfig, error) {
 	if d.barrierConfig.Load().(*SealConfig) != nil {
 		return d.barrierConfig.Load().(*SealConfig).Clone(), nil
 	}
@@ -198,8 +199,9 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 	}
 
 	sealType := "barrier"
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
 
-	entry, err := d.core.physical.Get(ctx, barrierSealConfigPath)
+	entry, err := d.core.physical.Get(ctx, view.Prefix())
 	if err != nil {
 		d.logger.Error("failed to read seal configuration", "seal_type", sealType, "error", err)
 		return nil, fmt.Errorf("failed to read %q seal configuration: %w", sealType, err)
@@ -235,7 +237,7 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 	return conf.Clone(), nil
 }
 
-func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig) error {
+func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig, ns *namespace.Namespace) error {
 	if err := d.checkCore(); err != nil {
 		return err
 	}
@@ -253,9 +255,11 @@ func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig) error
 		return fmt.Errorf("failed to encode barrier seal configuration: %w", err)
 	}
 
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+
 	// Store the seal configuration
 	pe := &physical.Entry{
-		Key:   barrierSealConfigPath,
+		Key:   view.Prefix(),
 		Value: buf,
 	}
 

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -1,0 +1,70 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	vaultseal "github.com/openbao/openbao/vault/seal"
+)
+
+type SealManager struct {
+	core    *Core
+	storage logical.Storage
+
+	// This lock ensures we don't concurrently modify the store while using
+	// a namespace entry. We also store an atomic to check if we need to
+	// reload all namespaces.
+	// lock        sync.RWMutex
+	// invalidated atomic.Bool
+
+	sealsByNamespace map[string][]*Seal
+
+	// logger is the server logger copied over from core
+	logger hclog.Logger
+}
+
+func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*SealManager, error) {
+	return &SealManager{
+		core:             core,
+		storage:          core.barrier,
+		sealsByNamespace: make(map[string][]*Seal),
+		logger:           logger,
+	}, nil
+}
+
+// setupSealManager is used to initialize the seal manager
+// when the vault is being unsealed.
+func (c *Core) setupSealManager(ctx context.Context) error {
+	var err error
+	sealLogger := c.baseLogger.Named("seal")
+	c.AddLogger(sealLogger)
+	c.sealManager, err = NewSealManager(ctx, c, sealLogger)
+	return err
+}
+
+func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *namespace.Namespace) error {
+	ctx = namespace.ContextWithNamespace(ctx, ns)
+
+	if err := sealConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid seal configuration: %w", err)
+	}
+
+	defaultSeal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+	defaultSeal.SetCore(sm.core)
+
+	if err := defaultSeal.Init(ctx); err != nil {
+		return fmt.Errorf("error initializing seal: %w", err)
+	}
+
+	sm.sealsByNamespace[ns.UUID] = []*Seal{&defaultSeal}
+	err := defaultSeal.SetBarrierConfig(ctx, sealConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set barrier config: %w", err)
+	}
+
+	return nil
+}

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
 )
 
 // TestDefaultSeal_Config exercises Shamir SetBarrierConfig and BarrierConfig.
 // Note that this is a little questionable, because we're doing an init and
 // unseal, then changing the barrier config using an internal function instead
-// of an API.  In other words if your change break this test, it might be more
+// of an API. In other words if your change break this test, it might be more
 // the test's fault than your changes.
 func TestDefaultSeal_Config(t *testing.T) {
 	bc := &SealConfig{
@@ -20,15 +22,16 @@ func TestDefaultSeal_Config(t *testing.T) {
 		SecretThreshold: 2,
 	}
 	core, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
 	defSeal := NewDefaultSeal(nil)
 	defSeal.SetCore(core)
-	err := defSeal.SetBarrierConfig(context.Background(), bc)
+	err := defSeal.SetBarrierConfig(ctx, bc, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newBc, err := defSeal.BarrierConfig(context.Background())
+	newBc, err := defSeal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,11 +42,45 @@ func TestDefaultSeal_Config(t *testing.T) {
 	// Now, test without the benefit of the cached value in the seal
 	defSeal = NewDefaultSeal(nil)
 	defSeal.SetCore(core)
-	newBc, err = defSeal.BarrierConfig(context.Background())
+	newBc, err = defSeal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*bc, *newBc) {
+		t.Fatal("config mismatch")
+	}
+
+	nsSealConfig := &SealConfig{
+		SecretShares:    10,
+		SecretThreshold: 5,
+	}
+
+	nsTest := &namespace.Namespace{Path: "test/"}
+	TestCoreCreateNamespaces(t, core, nsTest)
+
+	defSeal = NewDefaultSeal(nil)
+	defSeal.SetCore(core)
+	err = defSeal.SetBarrierConfig(ctx, nsSealConfig, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newNSSealConfig, err := defSeal.BarrierConfig(ctx, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*nsSealConfig, *newNSSealConfig) {
+		t.Fatal("config mismatch")
+	}
+
+	// Now, test without the benefit of the cached value in the seal
+	defSeal = NewDefaultSeal(nil)
+	defSeal.SetCore(core)
+	newNSSealConfig, err = defSeal.BarrierConfig(ctx, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*nsSealConfig, *newNSSealConfig) {
 		t.Fatal("config mismatch")
 	}
 }

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -327,9 +327,8 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 	barrierConfig := &SealConfig{
 		SecretShares:    3,
 		SecretThreshold: 3,
+		StoredShares:    1,
 	}
-
-	barrierConfig.StoredShares = 1
 
 	recoveryConfig := &SealConfig{
 		SecretShares:    3,
@@ -340,7 +339,7 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 		BarrierConfig:  barrierConfig,
 		RecoveryConfig: recoveryConfig,
 	}
-	result, err := core.Initialize(context.Background(), initParams)
+	result, err := core.Initialize(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), initParams)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -2111,7 +2110,7 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 		t.Fatal(err)
 	}
 
-	cfg, err := leader.Core.seal.BarrierConfig(ctx)
+	cfg, err := leader.Core.seal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR enables the (multiple) `sealConfig` uploads on a namespace creation.
This includes a creation of (barebones) `SealManager` that will track and handle the connection between namespaces and the seals (configs).