### PR TITLE
move initializeNamespace out of setNamespaceLocked

### DIFF
--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -275,27 +275,33 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
-		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+		entry, new, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			ns.CustomMetadata = metadata
 			return ns, nil
 		})
 		if err != nil {
 			return handleError(err)
 		}
+		if new {
+			// TODO(wslabosz): write all the provided configs
+			if len(sealConfigs) > 0 {
+				if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry); err != nil {
+					return handleError(err)
+				}
 
-		// TODO(wslabosz): write all the provided configs
-		if len(sealConfigs) > 0 {
-			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry.Clone()); err != nil {
-				return nil, err
-			}
-			nsSealKeyShares, err := b.Core.sealManager.InitializeBarrier(ctx, entry)
-			if err != nil {
-				return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
+				nsSealKeyShares, err := b.Core.sealManager.InitializeBarrier(ctx, entry)
+				if err != nil {
+					return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
+				}
+
+				// TODO Remove
+				for i, keyShare := range nsSealKeyShares {
+					fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+				}
 			}
 
-			// TODO Remove
-			for i, keyShare := range nsSealKeyShares {
-				fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+			if err := b.Core.namespaceStore.initializeNamespace(ctx, entry); err != nil {
+				return handleError(err)
 			}
 		}
 
@@ -328,7 +334,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
-		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+		ns, _, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			if ns.UUID == "" {
 				return nil, fmt.Errorf("requested namespace does not exist")
 			}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1459,7 +1459,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err := c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1467,7 +1467,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	// object lying around. This meant that list and subsequent create
 	// namespace operations returned this ghost structure and did not error
 	// properly. Retrying the create ensures no ghost object exists.
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1481,16 +1481,16 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
 	// Creating a new namespace should succeed.
-	nsBar, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
+	nsBar, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
 	require.NoError(t, err)
 	require.NotNil(t, nsBar)
 
@@ -1506,11 +1506,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1523,11 +1523,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -223,66 +223,55 @@ func (ns *NamespaceStore) SetNamespace(ctx context.Context, namespace *namespace
 
 	// Now grab write lock so that we can write to storage.
 	ns.lock.Lock()
-	return ns.setNamespaceLocked(ctx, namespace)
+	new, err := ns.setNamespaceLocked(ctx, namespace)
+	ns.lock.Unlock()
+	// TODO: might want to support calling (*SealManager).SetSeal here
+	if new {
+		ns.initializeNamespace(ctx, namespace)
+	}
+	return err
 }
 
 // setNamespaceLocked must be called while holding a write lock over the
-// NamespaceStore. This function unlocks the lock once finished.
-func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace) error {
-	// If we are creating a net-new namespace, we have to unlock before
-	// creating required mounts as the mount type will call
-	// GetNamespaceByAccessor. In that case, we will manually call
-	// ns.lock.Unlock() but in all other cases (including early exit)
-	// we _also_ need to unlock. So using a defer is preferable. Calling
-	// unlock twice may fail (either incorrectly releasing the write lock
-	// if someone else grabbed it or panicing if it was double unlocked)
-	// so we need a boolean here to determine whether or not our deferred
-	// unlock should actually be run.
-	var unlocked bool
-	defer func() {
-		if !unlocked {
-			ns.lock.Unlock()
-			unlocked = true
-		}
-	}()
-
+// NamespaceStore.
+func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace) (new bool, err error) {
 	// Copy the entry before validating and potentially mutating it.
 	entry := nsEntry.Clone()
 	if err := entry.Validate(); err != nil {
-		return logical.CodedError(http.StatusBadRequest, err.Error())
+		return false, logical.CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Validate that we have a parent namespace.
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("error loading parent namespace from context: %w", err)
+		return false, fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
 	var exists bool
 	if entry.UUID == "" {
 		id, err := ns.assignIdentifier(entry.Path)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		entry.ID = id
 		entry.UUID, err = uuid.GenerateUUID()
 		if err != nil {
-			return err
+			return false, err
 		}
 	} else {
 		var existing *namespace.Namespace
 		existing, exists = ns.namespacesByUUID[entry.UUID]
 		if !exists {
-			return errors.New("trying to update a non-existent namespace")
+			return false, errors.New("trying to update a non-existent namespace")
 		}
 
 		if existing.ID != entry.ID {
-			return errors.New("accessor ID does not match")
+			return false, errors.New("accessor ID does not match")
 		}
 
 		if existing.Path != entry.Path {
-			return errors.New("unable to remount namespace at new path")
+			return false, errors.New("unable to remount namespace at new path")
 		}
 	}
 
@@ -296,7 +285,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		path := entry.Path
 		if parent.ID != namespace.RootNamespaceID {
 			if !entry.HasParent(parent) {
-				return errors.New("namespace path lacks parent as a prefix")
+				return false, errors.New("namespace path lacks parent as a prefix")
 			}
 
 			path = namespace.Canonicalize(parent.TrimmedPath(entry.Path))
@@ -304,12 +293,12 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 
 		conflict := ns.core.router.matchingPrefixInternal(ctx, path)
 		if conflict != "" {
-			return fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
+			return false, fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
 		}
 	}
 
 	if err := ns.writeNamespace(ctx, entry); err != nil {
-		return fmt.Errorf("failed to persist namespace: %w", err)
+		return false, fmt.Errorf("failed to persist namespace: %w", err)
 	}
 	ns.namespacesByPath.Insert(entry)
 	ns.namespacesByUUID[entry.UUID] = entry
@@ -320,18 +309,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	nsEntry.ID = entry.ID
 	nsEntry.Path = entry.Path
 
-	if !exists {
-		// unlock before initializeNamespace since that will re-acquire the lock
-		ns.lock.Unlock()
-		unlocked = true
-
-		// Create sys/, token/ mounts and policies for the new namespace.
-		if err := ns.initializeNamespace(ctx, entry); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return true, nil
 }
 
 func (ns *NamespaceStore) writeNamespace(ctx context.Context, entry *namespace.Namespace) error {
@@ -515,30 +493,30 @@ func (ns *NamespaceStore) getNamespaceByPathLocked(ctx context.Context, path str
 // ModifyNamespace is used to perform modifications to a namespace while
 // holding a write lock to prevent other changes to namespaces from occurring
 // at the same time.
-func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, error) {
+func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, bool, error) {
 	defer metrics.MeasureSince([]string{"namespace", "modify_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	path = namespace.Canonicalize(parent.Path + path)
 	if path == "" {
-		return nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
+		return nil, false, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
 	}
 
 	ns.lock.Lock()
+	defer ns.lock.Unlock()
 
 	entry := ns.namespacesByPath.Get(path)
 	if entry != nil {
 		if entry.Tainted {
-			ns.lock.Unlock()
-			return nil, errors.New("namespace with that name exists and is currently tainted")
+			return nil, false, errors.New("namespace with that name exists and is currently tainted")
 		}
 		entry = entry.Clone()
 	} else {
@@ -551,17 +529,16 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 	if callback != nil {
 		entry, err = callback(ctx, entry)
 		if err != nil {
-			ns.lock.Unlock()
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	// setNamespaceLocked will unlock ns.lock
-	if err := ns.setNamespaceLocked(ctx, entry); err != nil {
-		return nil, err
+	new, err := ns.setNamespaceLocked(ctx, entry)
+	if err != nil {
+		return nil, new, err
 	}
 
-	return entry.Clone(), nil
+	return entry.Clone(), new, nil
 }
 
 // ListAllNamespaces lists all available namespaces, optionally including the


### PR DESCRIPTION
makes sure that the barrier is initialized before the namespace is initialized