### PR TITLE
write seal configs with correct barriers

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1067,6 +1067,10 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}
 
+	if err := c.setupSealManager(); err != nil {
+		return nil, fmt.Errorf("seal manager setup failed: %w", err)
+	}
+
 	// We create the funcs here, then populate the given config with it so that
 	// the caller can share state
 	conf.ReloadFuncsLock = &c.reloadFuncsLock
@@ -2272,9 +2276,6 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.setupNamespaceStore(ctx); err != nil {
 		return err
 	}
-	if err := c.setupSealManager(ctx); err != nil {
-		return err
-	}
 	if err := c.loadMounts(ctx); err != nil {
 		return err
 	}
@@ -2502,9 +2503,6 @@ func (c *Core) preSeal() error {
 	}
 	if err := c.unloadMounts(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
-	}
-	if err := c.teardownSealManager(); err != nil {
-		result = multierror.Append(result, fmt.Errorf("error tearing down seal manager: %w", err))
 	}
 	if err := c.teardownNamespaceStore(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down namespaces store: %w", err))

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -173,8 +173,8 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 
 func (b *SystemBackend) rawPaths() []*framework.Path {
 	r := &RawBackend{
-		barrier: b.Core.barrier,
-		logger:  b.logger,
+		core:   b.Core,
+		logger: b.logger,
 	}
 	return rawPaths("", r)
 }

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1459,16 +1459,18 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err := c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, new, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// In openbao#1198, the first creation erred but left a ghost namespace
 	// object lying around. This meant that list and subsequent create
 	// namespace operations returned this ghost structure and did not error
 	// properly. Retrying the create ensures no ghost object exists.
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a deeply nested mount should also cause failures.
@@ -1481,18 +1483,23 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a new namespace should succeed.
-	nsBar, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
+	nsBar, new, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
 	require.NoError(t, err)
+	require.True(t, new)
 	require.NotNil(t, nsBar)
+	err = c.namespaceStore.initializeNamespace(namespace.RootContext(nil), nsBar)
+	require.NoError(t, err)
 
 	barCtx := namespace.ContextWithNamespace(context.Background(), nsBar)
 
@@ -1506,12 +1513,14 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	me = &MountEntry{
@@ -1523,12 +1532,14 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a mount at the root level that conflicts with bar/ should fail.

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -309,7 +309,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	nsEntry.ID = entry.ID
 	nsEntry.Path = entry.Path
 
-	return true, nil
+	return !exists, nil
 }
 
 func (ns *NamespaceStore) writeNamespace(ctx context.Context, entry *namespace.Namespace) error {

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
+	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -161,24 +162,43 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace
 	}
 
 	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
+	barrier := d.core.sealManager.BarrierForStoragePath(view.Prefix())
 
-	// Fetch the core configuration
-	pe, err := d.core.physical.Get(ctx, view.Prefix())
-	if err != nil {
-		d.core.logger.Error("failed to read seal configuration", "error", err)
-		return nil, fmt.Errorf("failed to check seal configuration: %w", err)
-	}
+	var valueBytes []byte
+	if barrier != nil {
+		entry, err := barrier.Get(ctx, view.Prefix())
+		if err != nil {
+			d.core.logger.Error("failed to read seal configuration", "error", err)
+			return nil, fmt.Errorf("failed to check seal configuration: %w", err)
+		}
+		if entry == nil {
+			d.core.logger.Info("seal configuration missing, not initialized")
+			return nil, nil
+		}
 
-	// If the seal configuration is missing, we are not initialized
-	if pe == nil {
-		d.core.logger.Info("seal configuration missing, not initialized")
-		return nil, nil
+		valueBytes = entry.Value
+	} else {
+		// not encrypted
+		// Fetch the core configuration
+		pe, err := d.core.physical.Get(ctx, view.Prefix())
+		if err != nil {
+			d.core.logger.Error("failed to read seal configuration", "error", err)
+			return nil, fmt.Errorf("failed to check seal configuration: %w", err)
+		}
+
+		// If the seal configuration is missing, we are not initialized
+		if pe == nil {
+			d.core.logger.Info("seal configuration missing, not initialized")
+			return nil, nil
+		}
+
+		valueBytes = pe.Value
 	}
 
 	var conf SealConfig
 
 	// Decode the barrier entry
-	if err := jsonutil.DecodeJSON(pe.Value, &conf); err != nil {
+	if err := jsonutil.DecodeJSON(valueBytes, &conf); err != nil {
 		d.core.logger.Error("failed to decode seal configuration", "error", err)
 		return nil, fmt.Errorf("failed to decode seal configuration: %w", err)
 	}
@@ -231,16 +251,29 @@ func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig, 
 	}
 
 	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
+	barrier := d.core.sealManager.BarrierForStoragePath(view.Prefix())
 
-	// Store the seal configuration
-	pe := &physical.Entry{
-		Key:   view.Prefix(),
-		Value: buf,
-	}
-
-	if err := d.core.physical.Put(ctx, pe); err != nil {
-		d.core.logger.Error("failed to write seal configuration", "error", err)
-		return fmt.Errorf("failed to write seal configuration: %w", err)
+	if barrier != nil {
+		// Store the seal configuration
+		se := &logical.StorageEntry{
+			Key:   view.Prefix(),
+			Value: buf,
+		}
+		if err := barrier.Put(ctx, se); err != nil {
+			d.core.logger.Error("failed to write seal configuration", "error", err)
+			return fmt.Errorf("failed to write seal configuration: %w", err)
+		}
+	} else {
+		// Store the seal configuration
+		pe := &physical.Entry{
+			Key:   view.Prefix(),
+			Value: buf,
+		}
+		// not encrypted
+		if err := d.core.physical.Put(ctx, pe); err != nil {
+			d.core.logger.Error("failed to write seal configuration", "error", err)
+			return fmt.Errorf("failed to write seal configuration: %w", err)
+		}
 	}
 
 	d.SetCachedBarrierConfig(config.Clone())

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -45,6 +45,7 @@ type autoSeal struct {
 	recoveryConfig atomic.Value
 	core           *Core
 	logger         log.Logger
+	metaPrefix     string
 
 	hcLock          sync.Mutex
 	healthCheckStop chan struct{}
@@ -98,6 +99,10 @@ func (d *autoSeal) Init(ctx context.Context) error {
 	return d.Access.Init(ctx)
 }
 
+func (d *autoSeal) SetMetaPrefix(metaPrefix string) {
+	d.metaPrefix = metaPrefix
+}
+
 func (d *autoSeal) Finalize(ctx context.Context) error {
 	return d.Access.Finalize(ctx)
 }
@@ -121,13 +126,13 @@ func (d *autoSeal) RecoveryKeySupported() bool {
 // SetStoredKeys uses the autoSeal.Access.Encrypts method to wrap the keys. The stored entry
 // does not need to be seal wrapped in this case.
 func (d *autoSeal) SetStoredKeys(ctx context.Context, keys [][]byte) error {
-	return writeStoredKeys(ctx, d.core.physical, d.Access, keys)
+	return writeStoredKeys(ctx, d.core.physical, d.metaPrefix, d.Access, keys)
 }
 
 // GetStoredKeys retrieves the key shares by unwrapping the encrypted key using the
 // autoseal.
 func (d *autoSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {
-	return readStoredKeys(ctx, d.core.physical, d.Access)
+	return readStoredKeys(ctx, d.core.physical, d.metaPrefix, d.Access)
 }
 
 func (d *autoSeal) upgradeStoredKeys(ctx context.Context) error {

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -73,24 +73,27 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 		return fmt.Errorf("invalid seal configuration: %w", err)
 	}
 
+	metaPrefix := namespaceBarrierPrefix + ns.UUID + "/"
+
 	// Seal type would depend on the provided arguments
 	defaultSeal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
 	defaultSeal.SetCore(sm.core)
+	defaultSeal.SetMetaPrefix(metaPrefix)
 
 	if err := defaultSeal.Init(ctx); err != nil {
 		return fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	barrier, err := NewAESGCMBarrier(sm.core.physical, namespaceBarrierPrefix+ns.UUID+"/")
+	barrier, err := NewAESGCMBarrier(sm.core.physical, metaPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to construct namespace barrier: %w", err)
 	}
 	// barrier.Initialize(ctx context.Context, rootKey []byte, sealKey []byte, random io.Reader)
 	sm.barrierByNamespace.Insert(ns.Path, barrier)
-	sm.barrierByStoragePath.Insert(namespaceBarrierPrefix+ns.UUID+"/", barrier)
+	sm.barrierByStoragePath.Insert(metaPrefix, barrier)
 	parentBarrier := sm.ParentNamespaceBarrier(ns)
 	if parentBarrier != nil {
-		sm.barrierByStoragePath.Insert(namespaceBarrierPrefix+ns.UUID+"/"+barrierSealConfigPath, parentBarrier)
+		sm.barrierByStoragePath.Insert(metaPrefix+barrierSealConfigPath, parentBarrier)
 	}
 	sm.sealsByNamespace[ns.UUID] = []*Seal{&defaultSeal}
 	err = defaultSeal.SetBarrierConfig(ctx, sealConfig, ns)

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -22,8 +22,9 @@ type SealManager struct {
 	// lock        sync.RWMutex
 	// invalidated atomic.Bool
 
-	sealsByNamespace   map[string][]*Seal
-	barrierByNamespace *radix.Tree
+	sealsByNamespace     map[string][]*Seal
+	barrierByNamespace   *radix.Tree
+	barrierByStoragePath *radix.Tree
 
 	// logger is the server logger copied over from core
 	logger hclog.Logger
@@ -32,10 +33,11 @@ type SealManager struct {
 // NewSealManager creates a new seal manager with core reference and logger.
 func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*SealManager, error) {
 	return &SealManager{
-		core:               core,
-		sealsByNamespace:   make(map[string][]*Seal),
-		barrierByNamespace: radix.New(),
-		logger:             logger,
+		core:                 core,
+		sealsByNamespace:     make(map[string][]*Seal),
+		barrierByNamespace:   radix.New(),
+		barrierByStoragePath: radix.New(),
+		logger:               logger,
 	}, nil
 }
 
@@ -47,6 +49,8 @@ func (c *Core) setupSealManager(ctx context.Context) error {
 	c.AddLogger(sealLogger)
 	c.sealManager, err = NewSealManager(ctx, c, sealLogger)
 	c.sealManager.barrierByNamespace.Insert("", c.barrier)
+	c.sealManager.barrierByStoragePath.Insert("", c.barrier)
+	c.sealManager.barrierByStoragePath.Insert("core/seal-config", nil)
 	return err
 }
 
@@ -81,6 +85,11 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	}
 	// barrier.Initialize(ctx context.Context, rootKey []byte, sealKey []byte, random io.Reader)
 	sm.barrierByNamespace.Insert(ns.Path, barrier)
+	sm.barrierByStoragePath.Insert(namespaceBarrierPrefix+ns.UUID+"/", barrier)
+	parentBarrier := sm.ParentNamespaceBarrier(ns)
+	if parentBarrier != nil {
+		sm.barrierByStoragePath.Insert(namespaceBarrierPrefix+ns.UUID+"/"+barrierSealConfigPath, parentBarrier)
+	}
 	sm.sealsByNamespace[ns.UUID] = []*Seal{&defaultSeal}
 	err = defaultSeal.SetBarrierConfig(ctx, sealConfig, ns)
 	if err != nil {
@@ -88,6 +97,18 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	}
 
 	return nil
+}
+
+func (sm *SealManager) BarrierForStoragePath(path string) SecurityBarrier {
+	if sm == nil {
+		return nil
+	}
+	_, v, _ := sm.barrierByStoragePath.LongestPrefix(path)
+	if v == nil {
+		return nil
+	}
+	barrier := v.(SecurityBarrier)
+	return barrier
 }
 
 // SealNamespace seals the barriers of the given namespace and all of its children.
@@ -106,6 +127,24 @@ func (sm *SealManager) SealNamespace(ns *namespace.Namespace) error {
 	return errs
 }
 
+func (sm *SealManager) ParentNamespaceBarrier(ns *namespace.Namespace) SecurityBarrier {
+	parentPath, ok := ns.ParentPath()
+	if !ok {
+		return nil
+	}
+
+	_, v, _ := sm.barrierByNamespace.LongestPrefix(parentPath)
+	barrier := v.(SecurityBarrier)
+	return barrier
+}
+
+func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier {
+	_, v, _ := sm.barrierByNamespace.LongestPrefix(ns.Path)
+	barrier := v.(SecurityBarrier)
+
+	return barrier
+}
+
 // NamespaceView finds the correct barrier to use for the namespace and returns
 // the a BarrierView restricted to the data of the given namespace.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
@@ -115,8 +154,7 @@ func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
 	if c.sealManager == nil {
 		return NamespaceView(c.barrier, ns)
 	}
-	_, v, _ := c.sealManager.barrierByNamespace.LongestPrefix(ns.Path)
-	barrier := v.(SecurityBarrier)
+	barrier := c.sealManager.NamespaceBarrier(ns)
 	return NamespaceView(barrier, ns)
 }
 

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -10,6 +10,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/seal"
 	vaultseal "github.com/openbao/openbao/vault/seal"
 )
@@ -31,7 +33,7 @@ type SealManager struct {
 }
 
 // NewSealManager creates a new seal manager with core reference and logger.
-func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*SealManager, error) {
+func NewSealManager(core *Core, logger hclog.Logger) (*SealManager, error) {
 	return &SealManager{
 		core:                 core,
 		sealsByNamespace:     make(map[string][]*Seal),
@@ -43,11 +45,11 @@ func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*Seal
 
 // setupSealManager is used to initialize the seal manager
 // when the vault is being unsealed.
-func (c *Core) setupSealManager(ctx context.Context) error {
+func (c *Core) setupSealManager() error {
 	var err error
 	sealLogger := c.baseLogger.Named("seal")
 	c.AddLogger(sealLogger)
-	c.sealManager, err = NewSealManager(ctx, c, sealLogger)
+	c.sealManager, err = NewSealManager(c, sealLogger)
 	c.sealManager.barrierByNamespace.Insert("", c.barrier)
 	c.sealManager.barrierByStoragePath.Insert("", c.barrier)
 	c.sealManager.barrierByStoragePath.Insert("core/seal-config", nil)
@@ -99,16 +101,13 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	return nil
 }
 
-func (sm *SealManager) BarrierForStoragePath(path string) SecurityBarrier {
-	if sm == nil {
-		return nil
-	}
+func (sm *SealManager) StorageAccessForPath(path string) StorageAccess {
 	_, v, _ := sm.barrierByStoragePath.LongestPrefix(path)
 	if v == nil {
-		return nil
+		return &directStorageAccess{physical: sm.core.physical}
 	}
 	barrier := v.(SecurityBarrier)
-	return barrier
+	return &secureStorageAccess{barrier: barrier}
 }
 
 // SealNamespace seals the barriers of the given namespace and all of its children.
@@ -148,12 +147,6 @@ func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier
 // NamespaceView finds the correct barrier to use for the namespace and returns
 // the a BarrierView restricted to the data of the given namespace.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
-	// TODO: NamespaceView is called somewhere before sealManager is
-	// initialized. Figure out if we can fix the init sequence to make this go
-	// away
-	if c.sealManager == nil {
-		return NamespaceView(c.barrier, ns)
-	}
 	barrier := c.sealManager.NamespaceBarrier(ns)
 	return NamespaceView(barrier, ns)
 }
@@ -237,4 +230,78 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 	}
 
 	return nsSealKeyShares, nil
+}
+
+type StorageAccess interface {
+	Put(context.Context, string, []byte) error
+	Get(context.Context, string) ([]byte, error)
+	Delete(context.Context, string) error
+	ListPage(context.Context, string, string, int) ([]string, error)
+}
+
+var (
+	_ StorageAccess = (*directStorageAccess)(nil)
+	_ StorageAccess = (*secureStorageAccess)(nil)
+)
+
+type directStorageAccess struct {
+	physical physical.Backend
+}
+
+func (p *directStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	pe := &physical.Entry{
+		Key:   path,
+		Value: value,
+	}
+	return p.physical.Put(ctx, pe)
+}
+
+func (p *directStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	pe, err := p.physical.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if pe == nil {
+		return nil, nil
+	}
+	return pe.Value, nil
+}
+
+func (p *directStorageAccess) Delete(ctx context.Context, key string) error {
+	return p.physical.Delete(ctx, key)
+}
+
+func (p *directStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return p.physical.ListPage(ctx, prefix, after, limit)
+}
+
+type secureStorageAccess struct {
+	barrier SecurityBarrier
+}
+
+func (b *secureStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	se := &logical.StorageEntry{
+		Key:   path,
+		Value: value,
+	}
+	return b.barrier.Put(ctx, se)
+}
+
+func (b *secureStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	se, err := b.barrier.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if se == nil {
+		return nil, nil
+	}
+	return se.Value, nil
+}
+
+func (b *secureStorageAccess) Delete(ctx context.Context, key string) error {
+	return b.barrier.Delete(ctx, key)
+}
+
+func (b *secureStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return b.barrier.ListPage(ctx, prefix, after, limit)
 }


### PR DESCRIPTION
- writes the seal configs with the parent namespace seal (or unencrypted in case of root ns)
- makes /sys/raw use the correct barriers for reading values

not happy with the complexity of this, it would be nicer to have a noop-barrier that writes directly to a backing physical storage without encryption, then this could be used as barrier for `core/seal-config` of the root namespace and simplify a lot of this code.

I added a second commit that may simplify things a bit on the caller side, but adds a bit of complexity to the seal manager side.