### PR TITLE
Namespace sealing API implementation

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5818,6 +5818,12 @@ This path responds to the following HTTP methods.
 	PATCH /<path>
 		Update a namespace's custom metadata.
 
+	POST /seal/<path>
+		Seal a namespace.
+
+	POST /unseal/<path>
+		Unseal a namespace.
+
 	DELETE /<path>
 		Delete a namespace.
 		`,

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -81,6 +81,67 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 		},
 
 		{
+			Pattern: "namespaces/seal(?:$|/(?P<path>.+))",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Path of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Seal a namespace.",
+					Callback: b.handleNamespacesSeal(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: "OK"}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+		},
+		{
+			Pattern: "namespaces/unseal(?:$|/(?P<path>.+))",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Path of the namespace.",
+				},
+				"key": {
+					Type:        framework.TypeNameString,
+					Description: "Specifies a single namespace unseal key share.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Unseal a namespace.",
+					Callback: b.handleNamespacesUnseal(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: "OK"}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+		},
+
+		{
 			Pattern: "namespaces/(?P<path>.+)",
 
 			DisplayAttrs: &framework.DisplayAttributes{
@@ -390,5 +451,38 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 				"status": status,
 			},
 		}, nil
+	}
+}
+
+// TODO:
+func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+
+		err := b.Core.namespaceStore.SealNamespace(ctx, path)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"keys": "TBD",
+			},
+		}, nil
+	}
+}
+
+// TODO:
+func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+		key := data.Get("key").(string)
+
+		err := b.Core.namespaceStore.UnsealNamespace(ctx, path, []byte(key))
+		if err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
 	}
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -100,7 +100,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 					Summary:  "Seal a namespace.",
 					Callback: b.handleNamespacesSeal(),
 					Responses: map[int][]framework.Response{
-						http.StatusOK: {{Description: "OK"}},
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
 					},
 				},
 			},
@@ -132,7 +132,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 					Summary:  "Unseal a namespace.",
 					Callback: b.handleNamespacesUnseal(),
 					Responses: map[int][]framework.Response{
-						http.StatusOK: {{Description: "OK"}},
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
 					},
 				},
 			},
@@ -454,7 +454,7 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 	}
 }
 
-// TODO:
+// handleNamespacesSeal handles the "/sys/namespaces/seal/<path>" endpoint to seal the namespace.
 func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -464,15 +464,11 @@ func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
 			return handleError(err)
 		}
 
-		return &logical.Response{
-			Data: map[string]interface{}{
-				"keys": "TBD",
-			},
-		}, nil
+		return nil, nil
 	}
 }
 
-// TODO:
+// handleNamespacesUnseal handles the "/sys/namespaces/unseal/<path>" endpoint to unseal the namespace.
 func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -765,7 +765,7 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal root namespace")
 	}
 
-	if namespaceToSeal.Tainted && namespaceToSeal.IsDeleting {
+	if namespaceToSeal.Tainted || namespaceToSeal.IsDeleting {
 		return errors.New("unable to seal tainted or actively deleting namespace")
 	}
 

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -761,12 +761,12 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return nil
 	}
 
-	if namespaceToSeal.Tainted && namespaceToSeal.IsDeleting {
-		return nil
-	}
-
 	if namespaceToSeal.ID == namespace.RootNamespaceID {
 		return errors.New("unable to seal root namespace")
+	}
+
+	if namespaceToSeal.Tainted && namespaceToSeal.IsDeleting {
+		return errors.New("unable to seal tainted or actively deleting namespace")
 	}
 
 	err = ns.core.sealManager.SealNamespace(namespaceToSeal)
@@ -796,7 +796,7 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return nil
 	}
 
-	// TODO: verify the namespace is actuall sealed
+	// TODO: verify the namespace is actualy sealed
 	if namespaceToUnseal.ID == namespace.RootNamespaceID {
 		return errors.New("unable to unseal root namespace")
 	}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -742,6 +742,73 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 	return
 }
 
+// TODO:
+func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
+	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
+
+	if err := ns.checkInvalidation(ctx); err != nil {
+		return err
+	}
+
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	namespaceToSeal, err := ns.getNamespaceByPathLocked(ctx, path)
+	if err != nil {
+		return err
+	}
+	if namespaceToSeal == nil {
+		return nil
+	}
+
+	if namespaceToSeal.Tainted && namespaceToSeal.IsDeleting {
+		return nil
+	}
+
+	if namespaceToSeal.ID == namespace.RootNamespaceID {
+		return errors.New("unable to seal root namespace")
+	}
+
+	err = ns.core.sealManager.SealNamespace(namespaceToSeal)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO:
+func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key []byte) error {
+	defer metrics.MeasureSince([]string{"namespace", "unseal_namespace"}, time.Now())
+
+	if err := ns.checkInvalidation(ctx); err != nil {
+		return err
+	}
+
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	namespaceToUnseal, err := ns.getNamespaceByPathLocked(ctx, path)
+	if err != nil {
+		return err
+	}
+	if namespaceToUnseal == nil {
+		return nil
+	}
+
+	// TODO: verify the namespace is actuall sealed
+	if namespaceToUnseal.ID == namespace.RootNamespaceID {
+		return errors.New("unable to unseal root namespace")
+	}
+
+	err = ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal.Path, key)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ResolveNamespaceFromRequest resolves a namespace from the 'X-Vault-Namespace'
 // header combined with the request path, returning the namespace and the
 // "trimmed" request path devoid of any namespace components.

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -147,6 +147,18 @@ func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier
 	return barrier
 }
 
+// TODO(wslabosz): [PLACEHOLDER] UnsealNamespace unseals the barriers of the given namespace and all of its children.
+func (sm *SealManager) UnsealNamespace(ctx context.Context, path string, key []byte) error {
+	v, exists := sm.barrierByNamespace.Get(path)
+	if !exists {
+		return errors.New("barrier for the namespace doesn't exist")
+	}
+
+	sb := v.(SecurityBarrier)
+	err := sb.Unseal(ctx, key)
+	return err
+}
+
 // NamespaceView finds the correct barrier to use for the namespace and returns
 // the a BarrierView restricted to the data of the given namespace.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {


### PR DESCRIPTION
This PR introduces the scaffold of the support of seal/unseal namespace operations API.

```
bao namespace create ns1
curl -X POST -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/sys/namespaces/seal/ns1"

curl -X POST -H "X-Vault-Token: $(bao print token)" -d '{"key": "xxx"}' "http://127.0.0.1:8200/v1/sys/namespaces/unseal/ns1"
```