### PR TITLE
Namespace sealing/unsealing api adjustment

### DIFF
--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -117,7 +117,10 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 
 	data := map[string]interface{}{
 		"custom_metadata": c.flagCustomMetadata,
-		"seals":           seals,
+	}
+
+	if seals != nil {
+		data["seals"] = seals
 	}
 
 	secret, err := client.Logical().Write("sys/namespaces/"+namespacePath, data)

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -89,7 +89,7 @@ type SecurityBarrierCore interface {
 
 	// Sealed checks if the barrier has been unlocked yet. The Barrier
 	// is not expected to be able to perform any CRUD until it is unsealed.
-	Sealed() (bool, error)
+	Sealed() bool
 
 	// Unseal is used to provide the unseal key which permits the barrier
 	// to be unsealed. If the key is not correct, the barrier remains sealed.

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -338,11 +338,11 @@ func (b *AESGCMBarrier) KeyLength() (int, int) {
 
 // Sealed checks if the barrier has been unlocked yet. The Barrier
 // is not expected to be able to perform any CRUD until it is unsealed.
-func (b *AESGCMBarrier) Sealed() (bool, error) {
+func (b *AESGCMBarrier) Sealed() bool {
 	b.l.RLock()
 	sealed := b.sealed
 	b.l.RUnlock()
-	return sealed, nil
+	return sealed
 }
 
 // VerifyRoot is used to check if the given key matches the root key

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -123,8 +123,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.False(t, init, "should not be initialized")
 
 	// Should start sealed
-	sealed, err := b.Sealed()
-	require.NoError(t, err)
+	sealed := b.Sealed()
 	require.True(t, sealed, "should be sealed")
 
 	// Sealing should be a no-op
@@ -169,8 +168,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.True(t, init, "should be initialized")
 
 	// Should still be sealed
-	sealed, err = b.Sealed()
-	require.NoError(t, err)
+	sealed = b.Sealed()
 	require.True(t, sealed, "should be sealed")
 
 	// Unseal should work
@@ -182,8 +180,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.NoError(t, err)
 
 	// Should no longer be sealed
-	sealed, err = b.Sealed()
-	require.NoError(t, err)
+	sealed = b.Sealed()
 	require.False(t, sealed, "should be unsealed")
 
 	// Verify the root key

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -154,10 +154,7 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 	if c.Sealed() && !c.recoveryMode {
 		return consts.ErrSealed
 	}
-	barrierSealed, err := c.barrier.Sealed()
-	if err != nil {
-		return errors.New("unable to check barrier seal status")
-	}
+	barrierSealed := c.barrier.Sealed()
 	if !barrierSealed && c.recoveryMode {
 		return errors.New("attempt to generate recovery operation token when already unsealed")
 	}
@@ -240,10 +237,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, consts.ErrSealed
 	}
 
-	barrierSealed, err := c.barrier.Sealed()
-	if err != nil {
-		return nil, errors.New("unable to check barrier seal status")
-	}
+	barrierSealed := c.barrier.Sealed()
 	if !barrierSealed && c.recoveryMode {
 		return nil, errors.New("attempt to generate recovery operation token when already unsealed")
 	}

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -1023,11 +1023,7 @@ func (c *Core) scheduleUpgradeCleanup(ctx context.Context) error {
 
 	// Schedule cleanup for all of them
 	time.AfterFunc(c.KeyRotateGracePeriod(), func() {
-		sealed, err := c.barrier.Sealed()
-		if err != nil {
-			c.logger.Warn("failed to check barrier status at upgrade cleanup time")
-			return
-		}
+		sealed := c.barrier.Sealed()
 		if sealed {
 			c.logger.Warn("barrier sealed at upgrade cleanup time")
 			return

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5818,14 +5818,14 @@ This path responds to the following HTTP methods.
 	PATCH /<path>
 		Update a namespace's custom metadata.
 
-	POST /seal/<path>
-		Seal a namespace.
-
-	POST /unseal/<path>
-		Unseal a namespace.
-
 	DELETE /<path>
 		Delete a namespace.
+
+	POST /<name>/seal
+		Seal a namespace.
+
+	POST /<name/unseal
+		Unseal a namespace.
 		`,
 	},
 }

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -742,7 +742,8 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 	return
 }
 
-// TODO:
+// SealNamespace seals namespace with provided path, failing to do so if the namespace
+// doesn't exist, is a root namespace, is tainted or is actively deleting.
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 
@@ -757,8 +758,9 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 	if err != nil {
 		return err
 	}
+
 	if namespaceToSeal == nil {
-		return nil
+		return errors.New("namespace doesn't exist")
 	}
 
 	if namespaceToSeal.ID == namespace.RootNamespaceID {
@@ -777,7 +779,8 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 	return nil
 }
 
-// TODO:
+// UnsealNamespace unseals namespace with a given path, using provided key
+// TODO(wslabosz): track the unsealing progress in a SealManager
 func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key []byte) error {
 	defer metrics.MeasureSince([]string{"namespace", "unseal_namespace"}, time.Now())
 
@@ -796,7 +799,6 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return nil
 	}
 
-	// TODO: verify the namespace is actualy sealed
 	if namespaceToUnseal.ID == namespace.RootNamespaceID {
 		return errors.New("unable to unseal root namespace")
 	}


### PR DESCRIPTION
- Changed the url of the endpoints to use the `"namespaces/(?P<name>.+)/(un)seal"` pattern
- Adjusted the `Sealed()` method of the barrier for simplified "is namespace" sealed check
- Added `Sealed()` to unseal/seal methods of `SealManager`