### PR TITLE
Handle requests coming to sealed namespaces

### DIFF
--- a/sdk/helper/consts/error.go
+++ b/sdk/helper/consts/error.go
@@ -10,6 +10,10 @@ var (
 	// No operation is expected to succeed before unsealing
 	ErrSealed = errors.New("Vault is sealed")
 
+	// ErrNamespaceSealed is returned if an operation is performed on a sealed namesapce barrier.
+	// No operation is expected to succeed before unsealing
+	ErrNamespaceSealed = errors.New("Namespace is sealed")
+
 	// ErrAPILocked is returned if an operation is performed when the API is
 	// locked for the request namespace.
 	ErrAPILocked = errors.New("API access to this namespace has been locked by an administrator")

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -158,7 +158,7 @@ func AdjustErrorStatusCode(status *int, err error) {
 	}
 
 	// Adjust status code when sealed
-	if errwrap.Contains(err, consts.ErrSealed.Error()) {
+	if errwrap.Contains(err, consts.ErrSealed.Error()) || errwrap.Contains(err, consts.ErrNamespaceSealed.Error()) {
 		*status = http.StatusServiceUnavailable
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1391,6 +1391,11 @@ func (c *Core) Sealed() bool {
 	return atomic.LoadUint32(c.sealed) == 1
 }
 
+// IsNSSealed checks if the namespace is current sealed
+func (c *Core) IsNSSealed(ns *namespace.Namespace) bool {
+	return c.sealManager.NamespaceBarrier(ns).Sealed()
+}
+
 // SecretProgress returns the number of keys provided so far. Lock
 // should only be false if the caller is already holding the read
 // statelock (such as calls originating from switchedLockHandleRequest).

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -576,6 +576,10 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 		}
 	}
 
+	if c.IsNSSealed(ns) {
+		return nil, consts.ErrNamespaceSealed
+	}
+
 	isRestrictedSysAPI := ns.ID != namespace.RootNamespaceID &&
 		strings.HasPrefix(req.Path, "sys/") &&
 		restrictedSysAPIs.HasPathSegments(req.Path[len("sys/"):])

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -145,6 +145,7 @@ func (sm *SealManager) ParentNamespaceBarrier(ns *namespace.Namespace) SecurityB
 }
 
 func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier {
+	// this should acquire a lock
 	_, v, _ := sm.barrierByNamespace.LongestPrefix(ns.Path)
 	barrier := v.(SecurityBarrier)
 

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDefaultSeal_Config exercises Shamir SetBarrierConfig and BarrierConfig.
@@ -83,4 +84,26 @@ func TestDefaultSeal_Config(t *testing.T) {
 	if !reflect.DeepEqual(*nsSealConfig, *newNSSealConfig) {
 		t.Fatal("config mismatch")
 	}
+}
+
+func TestDefaultSeal_IsNSSealed(t *testing.T) {
+	sealConfig := &SealConfig{
+		Type:            "shamir",
+		SecretShares:    4,
+		SecretThreshold: 2,
+	}
+	c, _, _ := TestCoreUnsealed(t)
+	sm := c.sealManager
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	ns := &namespace.Namespace{Path: "test/"}
+	TestCoreCreateNamespaces(t, c, ns)
+	require.False(t, c.IsNSSealed(ns))
+
+	err := sm.SetSeal(ctx, sealConfig, ns)
+	require.NoError(t, err)
+
+	err = sm.SealNamespace(ns)
+	require.NoError(t, err)
+	require.True(t, c.IsNSSealed(ns))
 }


### PR DESCRIPTION
This PR introduces rejection of the requests coming to sealed namespace

- Added `(*Core).IsNSSealed()` method
- Added new error signature and its handling