### PR TITLE
Load sealed namespaces after unseal

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -597,6 +597,11 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
+		barrier := c.sealManager.NamespaceBarrier(ns)
+		if sealed, err := barrier.Sealed(); sealed || err != nil {
+			c.logger.Info(fmt.Sprintf("Barrier for namespace %v is sealed\n", ns.Path))
+			continue
+		}
 		view := c.NamespaceView(ns)
 
 		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -65,6 +65,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 		tokenStorer:   core,
 		entityCreator: core,
 		mfaBackend:    core.loginMFABackend,
+		core:          core,
 	}
 
 	// Create a memdb instance, which by default, operates on lower cased

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -2011,6 +2011,10 @@ func (i *IdentityStore) oidcPeriodicFunc(ctx context.Context) {
 			i.Logger().Error("error listing namespaces", "err", err)
 		}
 		for _, ns := range allNs {
+			barrier := i.core.sealManager.NamespaceBarrier(ns)
+			if sealed, err := barrier.Sealed(); sealed || err != nil {
+				continue
+			}
 			nsPath := ns.Path
 
 			s := i.router.MatchingStorageByAPIPath(ctx, nsPath+"identity/oidc")

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -103,6 +103,7 @@ type IdentityStore struct {
 	tokenStorer   TokenStorer
 	entityCreator EntityCreator
 	mfaBackend    *LoginMFABackend
+	core          *Core
 }
 
 type groupDiff struct {

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -346,7 +346,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		if new {
 			// TODO(wslabosz): write all the provided configs
 			if len(sealConfigs) > 0 {
-				if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry); err != nil {
+				if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry, true); err != nil {
 					return handleError(err)
 				}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1386,6 +1386,13 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
+		barrier := c.sealManager.NamespaceBarrier(ns)
+		c.logger.Info("loadTransactionalMounts")
+		if sealed, err := barrier.Sealed(); sealed || err != nil {
+			fmt.Printf("Barrier for namespace %v is sealed\n", ns.Path)
+			c.logger.Info("Barrier for namespace %v is sealed\n", ns.Path)
+			continue
+		}
 		view := c.NamespaceView(ns)
 		nsGlobal, nsLocal, err := listTransactionalMountsForNamespace(ctx, view)
 		if err != nil {

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -175,6 +175,15 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 			return false, err
 		}
 
+		isSealed, err := ns.core.sealManager.RegisterNamespace(ctx, &namespace)
+		fmt.Printf("Namespace: %v IsSealed %v\n", namespace.Path, isSealed)
+		if err != nil {
+			return false, fmt.Errorf("failed to register namespace %s with seal manager %w", namespace.ID, err)
+		}
+		if isSealed {
+			return true, nil
+		}
+
 		childView := ns.core.NamespaceView(&namespace).SubView(namespaceStoreSubPath)
 		if err := ns.loadNamespacesRecursive(ctx, barrier, childView, callback); err != nil {
 			return false, err


### PR DESCRIPTION
Load sealed namespaces after unseal of the vault.

1. Looks for sealConfig in the Namespace Path 
2. Initializes the Barrier and Seal but doesn't try to decrypt it
3. If no config is found it proceeds like before

