### PR TITLE
Namespace Seal Status Endpoint implementation

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -29,6 +29,9 @@ var reservedNames = []string{
 	"auth",
 	"cubbyhole",
 	"identity",
+	"seal",
+	"unseal",
+	"seal-status",
 }
 
 type (

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -15,15 +15,15 @@ import (
 var (
 	// ErrBarrierSealed is returned if an operation is performed on
 	// a sealed barrier. No operation is expected to succeed before unsealing
-	ErrBarrierSealed = errors.New("Vault is sealed")
+	ErrBarrierSealed = errors.New("Barrier is sealed")
 
 	// ErrBarrierAlreadyInit is returned if the barrier is already
 	// initialized. This prevents a re-initialization.
-	ErrBarrierAlreadyInit = errors.New("Vault is already initialized")
+	ErrBarrierAlreadyInit = errors.New("Barrier is already initialized")
 
 	// ErrBarrierNotInit is returned if a non-initialized barrier
 	// is attempted to be unsealed.
-	ErrBarrierNotInit = errors.New("Vault is not initialized")
+	ErrBarrierNotInit = errors.New("Barrier is not initialized")
 
 	// ErrBarrierInvalidKey is returned if the Unseal key is invalid
 	ErrBarrierInvalidKey = errors.New("Unseal failed, invalid key")

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -146,6 +146,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	b.Backend.Paths = append(b.Backend.Paths, b.lockedUserPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.leasePaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.policyPaths()...)
+	b.Backend.Paths = append(b.Backend.Paths, b.namespaceSealPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.namespacePaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.wrappingPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.toolsPaths()...)
@@ -5820,12 +5821,21 @@ This path responds to the following HTTP methods.
 
 	DELETE /<path>
 		Delete a namespace.
+		`,
+	},
+	"namespaces-seal": {
+		"Seal, unseal, check seal status of a namespace.",
+		`
+This path responds to the following HTTP methods.
 
 	POST /<name>/seal
 		Seal a namespace.
 
 	POST /<name/unseal
 		Unseal a namespace.
+		
+    GET /<name>/seal-status
+        Returns the seal status of the OpenBao instance.
 		`,
 	},
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5824,7 +5824,7 @@ This path responds to the following HTTP methods.
 		`,
 	},
 	"namespaces-seal": {
-		"Seal, unseal, check seal status of a namespace.",
+		"Seal, unseal and check seal status of a namespace.",
 		`
 This path responds to the following HTTP methods.
 
@@ -5835,7 +5835,7 @@ This path responds to the following HTTP methods.
 		Unseal a namespace.
 		
     GET /<name>/seal-status
-        Returns the seal status of the OpenBao instance.
+        Returns the seal status of the namespace.
 		`,
 	},
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -85,67 +84,6 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["list-namespaces"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["list-namespaces"][1]),
-		},
-
-		{
-			Pattern: "namespaces/(?P<name>.+)/seal",
-
-			DisplayAttrs: &framework.DisplayAttributes{
-				OperationPrefix: "namespaces",
-			},
-
-			Fields: map[string]*framework.FieldSchema{
-				"name": {
-					Type:        framework.TypeString,
-					Required:    true,
-					Description: "Name of the namespace.",
-				},
-			},
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.UpdateOperation: &framework.PathOperation{
-					Summary:  "Seal a namespace.",
-					Callback: b.handleNamespacesSeal(),
-					Responses: map[int][]framework.Response{
-						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
-					},
-				},
-			},
-
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
-		},
-		{
-			Pattern: "namespaces/(?P<name>.+)/unseal",
-
-			DisplayAttrs: &framework.DisplayAttributes{
-				OperationPrefix: "namespaces",
-			},
-
-			Fields: map[string]*framework.FieldSchema{
-				"name": {
-					Type:        framework.TypeString,
-					Required:    true,
-					Description: "Name of the namespace.",
-				},
-				"key": {
-					Type:        framework.TypeString,
-					Description: "Specifies a single namespace unseal key share.",
-				},
-			},
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.UpdateOperation: &framework.PathOperation{
-					Summary:  "Unseal a namespace.",
-					Callback: b.handleNamespacesUnseal(),
-					Responses: map[int][]framework.Response{
-						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
-					},
-				},
-			},
-
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
 		},
 
 		{
@@ -454,80 +392,5 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 				"status": status,
 			},
 		}, nil
-	}
-}
-
-// handleNamespacesSeal handles the "/sys/namespaces/<name>/seal" endpoint to seal the namespace.
-func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-		name := namespace.Canonicalize(data.Get("name").(string))
-
-		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
-			return nil, errors.New("name must not contain /")
-		}
-
-		err := b.Core.namespaceStore.SealNamespace(ctx, name)
-		if err != nil {
-			return handleError(err)
-		}
-
-		return nil, nil
-	}
-}
-
-// handleNamespacesUnseal handles the "/sys/namespaces/<name>/unseal" endpoint to unseal the namespace.
-func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-		name := namespace.Canonicalize(data.Get("name").(string))
-		key := data.Get("key").(string)
-
-		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
-			return nil, errors.New("name must not contain /")
-		}
-
-		if key == "" {
-			return nil, errors.New("provided key is empty")
-		}
-
-		var decodedKey []byte
-		decodedKey, err := hex.DecodeString(key)
-		if err != nil {
-			decodedKey, err = base64.StdEncoding.DecodeString(key)
-			if err != nil {
-				return handleError(err)
-			}
-		}
-
-		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, name)
-		if err != nil {
-			return handleError(err)
-		}
-
-		if ns == nil {
-			return nil, fmt.Errorf("namespace %q doesn't exist", name)
-		}
-
-		err = b.Core.sealManager.UnsealNamespace(ctx, ns, decodedKey)
-		if err != nil {
-			invalidKeyErr := &ErrInvalidKey{}
-			switch {
-			case errors.As(err, &invalidKeyErr):
-			case errors.Is(err, ErrBarrierInvalidKey):
-			case errors.Is(err, ErrBarrierNotInit):
-			case errors.Is(err, ErrBarrierSealed):
-			default:
-				return logical.RespondWithStatusCode(logical.ErrorResponse(err.Error()), req, http.StatusInternalServerError)
-			}
-			return handleError(err)
-		}
-
-		status, err := b.Core.sealManager.GetSealStatus(ctx, ns, true)
-		if err != nil {
-			return nil, err
-		}
-
-		return &logical.Response{Data: map[string]interface{}{
-			"seal_status": status,
-		}}, nil
 	}
 }

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -195,16 +194,11 @@ func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
 			return handleError(err)
 		}
 
-		buf, err := json.Marshal(status)
-		if err != nil {
-			return nil, err
+		if status == nil {
+			return nil, nil
 		}
 
-		return &logical.Response{Data: map[string]interface{}{
-			logical.HTTPStatusCode:  200,
-			logical.HTTPRawBody:     buf,
-			logical.HTTPContentType: "application/json",
-		}}, nil
+		return &logical.Response{Data: map[string]interface{}{"seal_status": status}}, nil
 	}
 }
 

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "namespaces/(?P<name>.+)/seal-status",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+				OperationVerb:   "status",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Summary:  "Check the seal status of an OpenBao namespace.",
+					Callback: b.handleNamespaceSealStatus(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Fields: map[string]*framework.FieldSchema{
+								"type": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"initialized": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"sealed": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"t": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"n": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"progress": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"nonce": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"version": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"build_date": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"migration": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"cluster_name": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+								"cluster_id": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+								"recovery_seal": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"storage_type": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+							},
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+
+		{
+			Pattern: "namespaces/(?P<name>.+)/seal",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Seal a namespace.",
+					Callback: b.handleNamespacesSeal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+		{
+			Pattern: "namespaces/(?P<name>.+)/unseal",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+				"key": {
+					Type:        framework.TypeString,
+					Description: "Specifies a single namespace unseal key share.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Unseal a namespace.",
+					Callback: b.handleNamespacesUnseal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+	}
+}
+
+// TODO: adjust comment when known what it does
+// handleNamespaceSealStatus handles the "/sys/namespaces/<name>/seal-status" endpoint to .
+func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", name)
+		}
+
+		status, err := b.Core.sealManager.GetSealStatus(ctx, ns, false)
+		if err != nil {
+			return handleError(err)
+		}
+
+		buf, err := json.Marshal(status)
+		if err != nil {
+			return nil, err
+		}
+
+		return &logical.Response{Data: map[string]interface{}{
+			logical.HTTPStatusCode:  200,
+			logical.HTTPRawBody:     buf,
+			logical.HTTPContentType: "application/json",
+		}}, nil
+	}
+}
+
+// handleNamespacesSeal handles the "/sys/namespaces/<name>/seal" endpoint to seal the namespace.
+func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		err := b.Core.namespaceStore.SealNamespace(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
+	}
+}
+
+// handleNamespacesUnseal handles the "/sys/namespaces/<name>/unseal" endpoint to unseal the namespace.
+func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+		key := data.Get("key").(string)
+
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		if key == "" {
+			return nil, errors.New("provided key is empty")
+		}
+
+		var decodedKey []byte
+		decodedKey, err := hex.DecodeString(key)
+		if err != nil {
+			decodedKey, err = base64.StdEncoding.DecodeString(key)
+			if err != nil {
+				return handleError(err)
+			}
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", name)
+		}
+
+		err = b.Core.sealManager.UnsealNamespace(ctx, ns, decodedKey)
+		if err != nil {
+			invalidKeyErr := &ErrInvalidKey{}
+			switch {
+			case errors.As(err, &invalidKeyErr):
+			case errors.Is(err, ErrBarrierInvalidKey):
+			case errors.Is(err, ErrBarrierNotInit):
+			case errors.Is(err, ErrBarrierSealed):
+			default:
+				return logical.RespondWithStatusCode(logical.ErrorResponse(err.Error()), req, http.StatusInternalServerError)
+			}
+			return handleError(err)
+		}
+
+		status, err := b.Core.sealManager.GetSealStatus(ctx, ns, true)
+		if err != nil {
+			return nil, err
+		}
+
+		return &logical.Response{Data: map[string]interface{}{
+			"seal_status": status,
+		}}, nil
+	}
+}

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -182,9 +182,14 @@ func (sm *SealManager) SecretProgress(ns *namespace.Namespace, lock bool) (int, 
 }
 
 func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespace, lock bool) (*SealStatusResponse, error) {
+	// Verify that any kind of seal exists for a namespace
+	seals, ok := sm.sealsByNamespace[ns.UUID]
+	if !ok {
+		return nil, errors.New("namespace is not set with a seal")
+	}
+
 	// Check the barrier first
 	barrier := sm.NamespaceBarrier(ns.Path)
-
 	init, err := barrier.Initialized(ctx)
 	if err != nil {
 		sm.logger.Error("namespace barrier init check failed", "namespace", ns.Path, "error", err)
@@ -195,8 +200,8 @@ func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespac
 		return nil, nil
 	}
 
-	seal := *sm.sealsByNamespace[ns.UUID]["default"]
 	// Verify the seal configuration
+	seal := *seals["default"]
 	sealConf, err := seal.BarrierConfig(ctx, ns)
 	if err != nil {
 		return nil, err

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -185,7 +185,7 @@ func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespac
 	// Verify that any kind of seal exists for a namespace
 	seals, ok := sm.sealsByNamespace[ns.UUID]
 	if !ok {
-		return nil, errors.New("namespace is not set with a seal")
+		return nil, nil
 	}
 
 	// Check the barrier first


### PR DESCRIPTION
This PR introduces `/sys/namespaces/<name>/seal-status` endpoint for retrieving the seal status of the namespace.