### PR TITLE
Unmounted namespaces from mountTables and authTables when namespace is sealed

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1201,7 +1201,7 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 	return nil
 }
 
-// unloadNamespaceMounts is used before we seal the namespace to reset the mounts to
+// UnloadNamespaceCredentialMounts is used before we seal the namespace to reset the mounts to
 // their unloaded state, calling Cleanup if defined
 func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespace.Namespace) error {
 	c.authLock.Lock()

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1202,9 +1202,14 @@ func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespac
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		return c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool {
+		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, false)
+		}, false); err != nil {
+			return err
+		}
+	}
+	if c.logger.IsInfo() {
+		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %s from auth table", ns.Path))
 	}
 	return nil
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,7 +1183,7 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, false, credentialRoutePrefix); err != nil {
+		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, credentialRoutePrefix); err != nil {
 			return err
 		}
 	}
@@ -1206,7 +1206,7 @@ func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespac
 		authTable := c.auth.shallowClone()
 		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, false, credentialRoutePrefix); err != nil {
+		}, credentialRoutePrefix); err != nil {
 			return err
 		}
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,9 +1183,7 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, credentialRoutePrefix); err != nil {
-			return err
-		}
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, func(e *MountEntry) bool { return true })
 	}
 
 	c.auth = nil
@@ -1204,11 +1202,9 @@ func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespac
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool {
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, credentialRoutePrefix); err != nil {
-			return err
-		}
+		})
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from auth table", ns.Path))

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,7 +1183,7 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, func(e *MountEntry) bool { return true })
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, false, func(e *MountEntry) bool { return true })
 	}
 
 	c.auth = nil
@@ -1196,15 +1196,13 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 // UnloadNamespaceCredentialMounts is used before we seal the namespace to reset the mounts to
 // their unloaded state, calling Cleanup if defined
-func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespace.Namespace) error {
+func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespace.Namespace, predicate func(*MountEntry) bool) error {
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, func(e *MountEntry) bool {
-			return e.namespace.UUID == ns.UUID
-		})
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, false, predicate)
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from auth table", ns.Path))

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,7 +1183,7 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, false); err != nil {
+		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, false, credentialRoutePrefix); err != nil {
 			return err
 		}
 	}
@@ -1206,12 +1206,12 @@ func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespac
 		authTable := c.auth.shallowClone()
 		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, false); err != nil {
+		}, false, credentialRoutePrefix); err != nil {
 			return err
 		}
 	}
 	if c.logger.IsInfo() {
-		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %s from auth table", ns.Path))
+		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from auth table", ns.Path))
 	}
 	return nil
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,7 +1183,9 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		return c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, false)
+		if err := c.cleanupMountBackends(ctx, authTable, func(e *MountEntry) bool { return true }, false); err != nil {
+			return err
+		}
 	}
 
 	c.auth = nil

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1201,6 +1201,27 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 	return nil
 }
 
+// unloadNamespaceMounts is used before we seal the namespace to reset the mounts to
+// their unloaded state, calling Cleanup if defined
+func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespace.Namespace) error {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	if c.auth != nil {
+		authTable := c.auth.shallowClone()
+		for _, e := range authTable.Entries {
+			if e.namespace.UUID == ns.UUID {
+				backend := c.router.MatchingBackend(namespace.ContextWithNamespace(ctx, e.namespace), credentialRoutePrefix+e.Path)
+				if backend != nil {
+					backend.Cleanup(ctx)
+				}
+				c.logger.Info("successfully unmounted", "type", e.Type, "version", e.RunningVersion, "path", e.Path, "namespace", e.Namespace())
+			}
+		}
+	}
+	return nil
+}
+
 // newCredentialBackend is used to create and configure a new credential backend by name.
 // It also returns the SHA256 of the plugin, if available.
 func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, string, error) {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1996,7 +1996,7 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 	defer c.mountsLock.Unlock()
 
 	if c.mounts != nil {
-		mountTable := c.auth.shallowClone()
+		mountTable := c.mounts.shallowClone()
 		err := c.cleanupMountBackends(ctx, mountTable, func(*MountEntry) bool { return true }, true)
 		if err != nil {
 			return err
@@ -2016,7 +2016,7 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 	defer c.mountsLock.Unlock()
 
 	if c.mounts != nil {
-		mountTable := c.auth.shallowClone()
+		mountTable := c.mounts.shallowClone()
 		return c.cleanupMountBackends(ctx, mountTable, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
 		}, true)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1992,8 +1992,8 @@ func (c *Core) setupMounts(ctx context.Context) error {
 // unloadMounts is used before we seal the vault to reset the mounts to
 // their unloaded state, calling Cleanup if defined. This is reversed by load and setup mounts.
 func (c *Core) unloadMounts(ctx context.Context) error {
-	c.authLock.Lock()
-	defer c.authLock.Unlock()
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
 
 	if c.mounts != nil {
 		mountTable := c.auth.shallowClone()
@@ -2012,8 +2012,8 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 // unloadNamespaceMounts is used before we seal the namespace to reset the mounts to
 // their unloaded state, calling Cleanup if defined
 func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespace) error {
-	c.authLock.Lock()
-	defer c.authLock.Unlock()
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
 
 	if c.mounts != nil {
 		mountTable := c.auth.shallowClone()

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2029,6 +2029,7 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 				if err := c.router.Unmount(nsCtx, e.Path); err != nil {
 					return err
 				}
+				c.logger.Info("successfully unmounted", "type", e.Type, "version", e.RunningVersion, "path", e.Path, "namespace", e.Namespace())
 			}
 		}
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2017,9 +2017,14 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 
 	if c.mounts != nil {
 		mountTable := c.mounts.shallowClone()
-		return c.cleanupMountBackends(ctx, mountTable, func(e *MountEntry) bool {
+		if err := c.cleanupMountBackends(ctx, mountTable, func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, true)
+		}, true); err != nil {
+			return err
+		}
+	}
+	if c.logger.IsInfo() {
+		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %s from mount table", ns.Path))
 	}
 	return nil
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1997,10 +1997,7 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 
 	if c.mounts != nil {
 		mountTable := c.mounts.shallowClone()
-		err := c.cleanupMountBackends(ctx, mountTable, func(*MountEntry) bool { return true }, "")
-		if err != nil {
-			return err
-		}
+		c.cleanupMountBackends(ctx, mountTable, "", func(*MountEntry) bool { return true })
 	}
 
 	c.mounts = nil
@@ -2017,11 +2014,9 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 
 	if c.mounts != nil {
 		mountTable := c.mounts.shallowClone()
-		if err := c.cleanupMountBackends(ctx, mountTable, func(e *MountEntry) bool {
+		c.cleanupMountBackends(ctx, mountTable, "", func(e *MountEntry) bool {
 			return e.namespace.UUID == ns.UUID
-		}, ""); err != nil {
-			return err
-		}
+		})
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from mount table", ns.Path))
@@ -2029,7 +2024,7 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 	return nil
 }
 
-func (c *Core) cleanupMountBackends(ctx context.Context, mountTable *MountTable, predicate func(*MountEntry) bool, pathPrefix string) error {
+func (c *Core) cleanupMountBackends(ctx context.Context, mountTable *MountTable, pathPrefix string, predicate func(*MountEntry) bool) {
 	for _, e := range mountTable.Entries {
 		if predicate(e) {
 			nsCtx := namespace.ContextWithNamespace(ctx, e.namespace)
@@ -2039,7 +2034,6 @@ func (c *Core) cleanupMountBackends(ctx context.Context, mountTable *MountTable,
 			}
 		}
 	}
-	return nil
 }
 
 // newLogicalBackend is used to create and configure a new logical backend by name.

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -779,7 +779,7 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal tainted or actively deleting namespace")
 	}
 
-	err = ns.core.sealManager.SealNamespace(namespaceToSeal)
+	err = ns.core.sealManager.SealNamespace(ctx, namespaceToSeal)
 	if err != nil {
 		return err
 	}

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -144,10 +144,11 @@ func (sm *SealManager) SealNamespace(ctx context.Context, ns *namespace.Namespac
 		if descendantNamespace == nil {
 			errs = errors.Join(errs, fmt.Errorf("namespace not found for path: %s", p))
 		}
-		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, descendantNamespace); err != nil {
+		sm.core.namespaceStore.ClearNamespacePolicies(ctx, descendantNamespace, false)
+		if err := sm.core.namespaceStore.UnloadNamespaceCredentials(ctx, descendantNamespace); err != nil {
 			errs = errors.Join(errs, err)
 		}
-		if err := sm.core.UnloadNamespaceMounts(ctx, descendantNamespace); err != nil {
+		if err := sm.core.namespaceStore.UnloadNamespaceMounts(ctx, descendantNamespace); err != nil {
 			errs = errors.Join(errs, err)
 		}
 		err = s.Seal()

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -144,10 +144,10 @@ func (sm *SealManager) SealNamespace(ctx context.Context, ns *namespace.Namespac
 		if childNS == nil {
 			errs = errors.Join(errs, fmt.Errorf("Child Namespace not found for path: %s", p))
 		}
-		if err := sm.core.UnloadNamespaceMounts(ctx, childNS); err != nil {
+		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, childNS); err != nil {
 			errs = errors.Join(errs, err)
 		}
-		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, childNS); err != nil {
+		if err := sm.core.UnloadNamespaceMounts(ctx, childNS); err != nil {
 			errs = errors.Join(errs, err)
 		}
 		err = s.Seal()

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -147,6 +147,9 @@ func (sm *SealManager) SealNamespace(ctx context.Context, ns *namespace.Namespac
 		if err := sm.core.UnloadNamespaceMounts(ctx, childNS); err != nil {
 			errs = errors.Join(errs, err)
 		}
+		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, childNS); err != nil {
+			errs = errors.Join(errs, err)
+		}
 		err = s.Seal()
 		if err != nil {
 			errs = errors.Join(errs, err)

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -195,9 +195,14 @@ func (sm *SealManager) SecretProgress(ns *namespace.Namespace, lock bool) (int, 
 }
 
 func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespace, lock bool) (*SealStatusResponse, error) {
+	// Verify that any kind of seal exists for a namespace
+	seals, ok := sm.sealsByNamespace[ns.UUID]
+	if !ok {
+		return nil, nil
+	}
+
 	// Check the barrier first
 	barrier := sm.NamespaceBarrier(ns.Path)
-
 	init, err := barrier.Initialized(ctx)
 	if err != nil {
 		sm.logger.Error("namespace barrier init check failed", "namespace", ns.Path, "error", err)
@@ -208,8 +213,8 @@ func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespac
 		return nil, nil
 	}
 
-	seal := *sm.sealsByNamespace[ns.UUID]["default"]
 	// Verify the seal configuration
+	seal := *seals["default"]
 	sealConf, err := seal.BarrierConfig(ctx, ns)
 	if err != nil {
 		return nil, err

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -137,17 +137,17 @@ func (sm *SealManager) SealNamespace(ctx context.Context, ns *namespace.Namespac
 		if s.Sealed() {
 			return false
 		}
-		childNS, err := sm.core.namespaceStore.getNamespaceByPathLocked(ctx, namespace.Canonicalize(p))
+		descendantNamespace, err := sm.core.namespaceStore.getNamespaceByPathLocked(ctx, namespace.Canonicalize(p))
 		if err != nil {
 			errs = errors.Join(errs, err)
 		}
-		if childNS == nil {
-			errs = errors.Join(errs, fmt.Errorf("Child Namespace not found for path: %s", p))
+		if descendantNamespace == nil {
+			errs = errors.Join(errs, fmt.Errorf("namespace not found for path: %s", p))
 		}
-		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, childNS); err != nil {
+		if err := sm.core.UnloadNamespaceCredentialMounts(ctx, descendantNamespace); err != nil {
 			errs = errors.Join(errs, err)
 		}
-		if err := sm.core.UnloadNamespaceMounts(ctx, childNS); err != nil {
+		if err := sm.core.UnloadNamespaceMounts(ctx, descendantNamespace); err != nil {
 			errs = errors.Join(errs, err)
 		}
 		err = s.Seal()

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -103,7 +103,7 @@ func TestDefaultSeal_IsNSSealed(t *testing.T) {
 	err := sm.SetSeal(ctx, sealConfig, ns, true)
 	require.NoError(t, err)
 
-	err = sm.SealNamespace(ns)
+	err = sm.SealNamespace(ctx, ns)
 	require.NoError(t, err)
 	require.True(t, c.IsNSSealed(ns))
 }


### PR DESCRIPTION
Created new branch because rebase wouldn't work in old branch... 

- Added a new function cleanupMountBackends in mount.go, which is used by mount.go and auth.go to unmount all or specific entries using a filter function
- Unmounted namespace mounts when a namespace is sealed