### PR TITLE
Fix sealed namespaces mounting after core unseal

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -597,10 +597,6 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
-		if c.IsNSSealed(ns) {
-			c.logger.Info(fmt.Sprintf("Barrier for namespace %v is sealed\n", ns.Path))
-			continue
-		}
 		view := c.NamespaceView(ns)
 
 		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)

--- a/vault/core.go
+++ b/vault/core.go
@@ -3263,7 +3263,7 @@ func (c *Core) isPrimary() bool {
 
 func (c *Core) loadLoginMFAConfigs(ctx context.Context) error {
 	eConfigs := make([]*mfa.MFAEnforcementConfig, 0)
-	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true, true)
 	if err != nil {
 		return err
 	}
@@ -3372,7 +3372,7 @@ func (c *Core) runLockedUserEntryUpdates(ctx context.Context) error {
 	}
 
 	// get all namespaces
-	nsList, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	nsList, err := c.namespaceStore.ListAllNamespaces(ctx, true, true)
 	if err != nil {
 		return err
 	}

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -415,7 +415,7 @@ func (c *Core) entityGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLab
 
 	// No check for expiration here; the bulk of the work should be in
 	// counting the entities.
-	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true, true)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}

--- a/vault/counters.go
+++ b/vault/counters.go
@@ -30,7 +30,7 @@ type TokenCounter struct {
 // countActiveTokens returns the number of active tokens
 func (c *Core) countActiveTokens(ctx context.Context) (*ActiveTokens, error) {
 	// Get all of the namespaces
-	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -2011,9 +2011,6 @@ func (i *IdentityStore) oidcPeriodicFunc(ctx context.Context) {
 			i.Logger().Error("error listing namespaces", "err", err)
 		}
 		for _, ns := range allNs {
-			if i.namespacer.IsNSSealed(ns) {
-				continue
-			}
 			nsPath := ns.Path
 
 			s := i.router.MatchingStorageByAPIPath(ctx, nsPath+"identity/oidc")

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -131,7 +131,6 @@ var _ LocalNode = &Core{}
 type Namespacer interface {
 	NamespaceByID(context.Context, string) (*namespace.Namespace, error)
 	ListNamespaces(context.Context) ([]*namespace.Namespace, error)
-	IsNSSealed(ns *namespace.Namespace) bool
 }
 
 var _ Namespacer = &Core{}

--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -100,15 +100,18 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 		return totalCounts, lockedUsersResponse, nil
 	}
 
-	// no mount_accessor is provided in request, get information for current namespace and its child namespaces
-
-	// get all the namespaces
+	// no mount_accessor is provided in request, get information
+	// for current namespace and its all unsealed child namespaces
 	nsList, err := b.Core.namespaceStore.ListNamespaces(ctx, true, true)
 	if err != nil {
 		return 0, nil, err
 	}
 
 	for _, ns := range nsList {
+		// skip sealed namespaces
+		if b.Core.IsNSSealed(ns) {
+			continue
+		}
 		// get mount accessors of locked users for this namespace
 		view := NamespaceView(b.Core.barrier, ns).SubView(coreLockedUsersPath)
 		mountAccessors, err := view.List(ctx, "")

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1386,9 +1386,6 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
-		if c.IsNSSealed(ns) {
-			continue
-		}
 		view := c.NamespaceView(ns)
 		nsGlobal, nsLocal, err := listTransactionalMountsForNamespace(ctx, view)
 		if err != nil {

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -22,7 +22,7 @@ func TestNamespaceStore(t *testing.T) {
 	ctx := namespace.RootContext(context.TODO())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaces(ctx, false)
+	ns, err := s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -43,7 +43,7 @@ func TestNamespaceStore(t *testing.T) {
 	itemPath := item.Path
 
 	// We should now have one item.
-	ns, err = s.ListAllNamespaces(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
 	require.Equal(t, ns[0].UUID, item.UUID)
@@ -85,7 +85,7 @@ func TestNamespaceStore(t *testing.T) {
 	s = c.namespaceStore
 
 	// We should still have one item.
-	ns, err = s.ListAllNamespaces(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
 	require.Equal(t, ns[0].UUID, itemUUID)
@@ -98,7 +98,7 @@ func TestNamespaceStore(t *testing.T) {
 	// Wait until deletion has finished.
 	maxRetries := 50
 	for range maxRetries {
-		ns, err = s.ListAllNamespaces(ctx, false)
+		ns, err = s.ListAllNamespaces(ctx, false, false)
 		require.NoError(t, err)
 		if len(ns) > 0 {
 			time.Sleep(1 * time.Millisecond)
@@ -108,7 +108,7 @@ func TestNamespaceStore(t *testing.T) {
 	}
 
 	// Store should be empty.
-	ns, err = s.ListAllNamespaces(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -129,7 +129,7 @@ func TestNamespaceStore(t *testing.T) {
 	// however, the s.SetNamespace function is still using the previous namespace.
 	s = c.namespaceStore
 
-	ns, err = s.ListAllNamespaces(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -179,7 +179,7 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	}
 
 	// verify namespace deletion
-	nsList, err := s.ListAllNamespaces(ctx, false)
+	nsList, err := s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.Empty(t, nsList)
 
@@ -309,7 +309,7 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	require.Empty(t, ret.UnlockKey)
 
 	// Verify that listing does not return locks.
-	all, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	all, err := c.namespaceStore.ListAllNamespaces(ctx, true, false)
 	require.NoError(t, err)
 	for index, ns := range all {
 		require.Empty(t, ns.UnlockKey, "namespace: %v / index: %v", ns, index)
@@ -405,7 +405,7 @@ func TestNamespaceHierarchy(t *testing.T) {
 	ctx := namespace.RootContext(context.TODO())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaces(ctx, false)
+	ns, err := s.ListAllNamespaces(ctx, false, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -438,7 +438,7 @@ func TestNamespaceHierarchy(t *testing.T) {
 
 	t.Run("ListNamespaces", func(t *testing.T) {
 		t.Run("no root namespace", func(t *testing.T) {
-			nsList, err := s.ListAllNamespaces(ctx, false)
+			nsList, err := s.ListAllNamespaces(ctx, false, false)
 			require.NoError(t, err)
 			containsRoot := false
 			for _, nss := range nsList {
@@ -451,7 +451,7 @@ func TestNamespaceHierarchy(t *testing.T) {
 			require.Equal(t, len(namespaces), len(nsList), "ListAllNamespaces must return all namespaces, excluding root")
 		})
 		t.Run("with root namespace", func(t *testing.T) {
-			nsList, err := s.ListAllNamespaces(ctx, true)
+			nsList, err := s.ListAllNamespaces(ctx, true, false)
 			require.NoError(t, err)
 			containsRoot := false
 			for _, nss := range nsList {
@@ -626,7 +626,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("ListAllNamespaces", func(b *testing.B) {
 		for b.Loop() {
-			s.ListAllNamespaces(ctx, false)
+			s.ListAllNamespaces(ctx, false, false)
 		}
 	})
 

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -20,8 +20,10 @@ func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Names
 	return ns, nil
 }
 
+// ListNamespaces returns back a list of all namespaces, including root, skipping
+// all sealed namespaces.
 func (c *Core) ListNamespaces(ctx context.Context) ([]*namespace.Namespace, error) {
-	return c.namespaceStore.ListAllNamespaces(ctx, true)
+	return c.namespaceStore.ListAllNamespaces(ctx, true, true)
 }
 
 func NamespaceView(barrier logical.Storage, ns *namespace.Namespace) BarrierView {

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3900,7 +3900,7 @@ func (ts *TokenStore) gaugeCollector(ctx context.Context) ([]metricsutil.GaugeLa
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, false)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -3959,7 +3959,7 @@ func (ts *TokenStore) gaugeCollectorByPolicy(ctx context.Context) ([]metricsutil
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, false)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -4021,7 +4021,7 @@ func (ts *TokenStore) gaugeCollectorByTtl(ctx context.Context) ([]metricsutil.Ga
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, false)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -4093,7 +4093,7 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 	}
 
 	rootContext := namespace.RootContext(ctx)
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, false)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}


### PR DESCRIPTION
Resolves the bug with the sealed namespace being missing from the identity store memDB, when it was intentionally omitted from loading after the sealing (as namespace got sealed). This also applies for any other possible backend system that should not load the sealed namespace after the unseal of the bao instance.

Result of live-coding session with:
@Huy-Dinh-Reply @rencooo 