### PR TITLE
Prevent partially created namespace on bad seal config

### DIFF
--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -362,6 +362,13 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			if err != nil {
 				return logical.ErrorResponse("error while extracting seal configs"), err
 			}
+
+			// Check if all the seal configs are valid
+			for _, sealConfig := range sealConfigs {
+				if err := sealConfig.Validate(); err != nil {
+					return logical.ErrorResponse("invalid seal config: %v", err), err
+				}
+			}
 		}
 
 		entry, new, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -143,6 +143,25 @@ func TestNamespaceBackend_Set(t *testing.T) {
 		require.Equal(t, res.Data["custom_metadata"], newMetadata,
 			"read custom_metadata does not match original custom_metadata")
 	})
+
+	t.Run("create namespace with bad seal config should fail", func(t *testing.T) {
+		sealConfig := map[string]interface{}{
+			"type":             "shamir",
+			"secret_shares":    0, // Invalid secret_shares
+			"secret_threshold": 0, // Invalid secret_threshold
+		}
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/bad_seal_ns")
+		req.Data["seals"] = sealConfig
+		_, err := b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+
+		// namespace should not have been created
+		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/bad_seal_ns")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Empty(t, res, "expected empty response")
+	})
 }
 
 func TestNamespaceBackend_Read(t *testing.T) {


### PR DESCRIPTION
- Check if seal configs are valid before creating namespace.