### PR TITLE
Handle mount and auth table on namespace sealing/unsealing

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -326,6 +326,11 @@ func (c *Core) removeCredEntry(ctx context.Context, path string, updateStorage b
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
+	return c.removeCredEntryLocked(ctx, path, updateStorage)
+}
+
+// removeCredEntry is used to remove an entry in the auth table, should only be called when authLock is locked
+func (c *Core) removeCredEntryLocked(ctx context.Context, path string, updateStorage bool) error {
 	// Taint the entry from the auth table
 	newTable := c.auth.shallowClone()
 	entry, err := newTable.remove(ctx, path)
@@ -667,6 +672,110 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		return err
 	}
 
+	return nil
+}
+
+// loadCredentialsForNamespace is used to load auth mounts to the mount table for a namespace
+func (c *Core) loadCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	if _, ok := c.barrier.(logical.TransactionalStorage); !ok {
+		return c.loadLegacyCredentialsForNamespace(ctx, ns)
+	}
+	return c.loadTransactionalCredentialsForNamespace(ctx, ns)
+}
+
+// loadLegacyCredentialsForNamespace is used to load the auth mounts of a namespace on a legacy single-entry
+// format from a non-transactional storage to the mount table
+func (c *Core) loadLegacyCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if ns == nil {
+		return fmt.Errorf("namespace is nil")
+	}
+
+	if c.IsNSSealed(ns) {
+		return fmt.Errorf("namespace is sealed")
+	}
+
+	view := c.NamespaceView(ns)
+
+	// Load the existing auth mount table
+	raw, err := view.Get(ctx, coreAuthConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read auth table", "error", err)
+		return errLoadAuthFailed
+	}
+	rawLocal, err := view.Get(ctx, coreLocalAuthConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read local auth table", "error", err)
+		return errLoadAuthFailed
+	}
+
+	if raw != nil {
+		authTable, err := c.decodeMountTable(ctx, raw.Value)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the auth table", "error", err)
+			return err
+		}
+		if authTable != nil {
+			c.auth.Entries = append(c.auth.Entries, authTable.Entries...)
+		}
+	}
+
+	if rawLocal != nil {
+		localAuthTable, err := c.decodeMountTable(ctx, rawLocal.Value)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy local auth mount table", "error", err)
+			return err
+		}
+		if localAuthTable != nil {
+			c.auth.Entries = append(c.auth.Entries, localAuthTable.Entries...)
+		}
+	}
+
+	return nil
+}
+
+// loadTransactionalCredentialsForNamespace is used to load the auth mounts of a namespace on a transactional
+// storage to the mount table
+func (c *Core) loadTransactionalCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if ns == nil {
+		return fmt.Errorf("namespace is nil")
+	}
+
+	if c.IsNSSealed(ns) {
+		return fmt.Errorf("namespace is sealed")
+	}
+
+	view := c.NamespaceView(ns)
+
+	globalEntries, localEntries, err := c.listTransactionalCredentialsForNamespace(ctx, view)
+	if err != nil {
+		c.logger.Error("failed to list transactional auth mounts for namespace", "error", err, "namespace", ns.ID)
+		return err
+	}
+
+	for index, uuid := range globalEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreAuthConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading auth mount table entry (%v %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.auth.Entries = append(c.auth.Entries, entry)
+		}
+	}
+
+	for index, uuid := range localEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading local auth mount table entry (%v %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.auth.Entries = append(c.auth.Entries, entry)
+		}
+	}
 	return nil
 }
 
@@ -1054,6 +1163,132 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 	return nil
 }
 
+// setupCredential is invoked for each auth mount entry to
+// initialize the credential backend and setup the router
+func (c *Core) setupCredential(ctx context.Context, entry *MountEntry) (func(), error) {
+	view, err := c.mountEntryView(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	origViewReadOnlyErr := view.GetReadOnlyErr()
+
+	// Mark the view as read-only until the mounting is complete and
+	// ensure that it is reset after. This ensures that there will be no
+	// writes during the construction of the backend.
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	if strutil.StrListContains(singletonMounts, entry.Type) {
+		defer view.SetReadOnlyErr(origViewReadOnlyErr)
+	}
+
+	// Initialize the backend
+	sysView := c.mountEntrySysView(entry)
+
+	var backend logical.Backend
+	backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
+	if err != nil {
+		c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
+
+		if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
+			c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
+			goto ROUTER_MOUNT
+		}
+		return nil, errLoadAuthFailed
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("nil backend returned from %q factory", entry.Type)
+	}
+
+	// update the entry running version with the configured version, which was verified during registration.
+	entry.RunningVersion = entry.Version
+	if entry.RunningVersion == "" {
+		// don't set the running version to a builtin if it is running as an external plugin
+		if entry.RunningSha256 == "" {
+			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
+		}
+	}
+
+	// Do not start up deprecated builtin plugins. If this is a major
+	// upgrade, stop unsealing and shutdown. If we've already mounted this
+	// plugin, skip backend initialization and mount the data for posterity.
+	if versions.IsBuiltinVersion(entry.RunningVersion) {
+		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
+		if c.isMajorVersionFirstMount(ctx) && err != nil {
+			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+			return nil, errLoadAuthFailed
+		} else if err != nil {
+			c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
+			backend.Cleanup(ctx)
+			backend = nil
+			goto ROUTER_MOUNT
+		}
+	}
+
+	{
+		// Check for the correct backend type
+		backendType := backend.Type()
+		if backendType != logical.TypeCredential {
+			return nil, fmt.Errorf("cannot mount %q of type %q as an auth backend", entry.Type, backendType)
+		}
+	}
+
+ROUTER_MOUNT:
+	// Mount the backend
+	path := credentialRoutePrefix + entry.Path
+	err = c.router.Mount(backend, path, entry, view)
+	if err != nil {
+		c.logger.Error("failed to mount auth entry", "path", entry.Path, "namespace", entry.Namespace(), "error", err)
+		return nil, errLoadAuthFailed
+	}
+
+	if c.logger.IsInfo() {
+		c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace())
+	}
+
+	// Ensure the path is tainted if set in the mount table
+	if entry.Tainted {
+		// Calculate any namespace prefixes here, because when Taint() is called, there won't be
+		// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
+		path = entry.Namespace().Path + path
+		c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
+		c.router.Taint(ctx, path)
+	}
+
+	// Check if this is the token store
+	if entry.Type == mountTypeToken {
+		c.tokenStore = backend.(*TokenStore)
+
+		// At some point when this isn't beta we may persist this but for
+		// now always set it on mount
+		entry.Config.TokenType = logical.TokenTypeDefaultService
+
+		// this is loaded *after* the normal mounts, including cubbyhole
+		c.router.tokenStoreSaltFunc = c.tokenStore.Salt
+		c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, mountPathCubbyhole).(*CubbyholeBackend)
+	}
+
+	// Initialize
+	// Bind locally
+	localEntry := entry
+	postUnsealFunc := func() {
+		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
+		if backend == nil {
+			postUnsealLogger.Error("skipping initialization for nil auth backend")
+			return
+		}
+		if !strutil.StrListContains(singletonMounts, localEntry.Type) {
+			view.SetReadOnlyErr(origViewReadOnlyErr)
+		}
+
+		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
+		if err != nil {
+			postUnsealLogger.Error("failed to initialize auth backend", "error", err)
+		}
+	}
+
+	return postUnsealFunc, nil
+}
+
 // setupCredentials is invoked after we've loaded the auth table to
 // initialize the credential backends and setup the router
 func (c *Core) setupCredentials(ctx context.Context) error {
@@ -1061,128 +1296,44 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 	defer c.authLock.Unlock()
 
 	for _, entry := range c.auth.sortEntriesByPathDepth().Entries {
-		view, err := c.mountEntryView(entry)
+		postUnsealFunc, err := c.setupCredential(ctx, entry)
 		if err != nil {
 			return err
 		}
 
-		origViewReadOnlyErr := view.GetReadOnlyErr()
-
-		// Mark the view as read-only until the mounting is complete and
-		// ensure that it is reset after. This ensures that there will be no
-		// writes during the construction of the backend.
-		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-		if strutil.StrListContains(singletonMounts, entry.Type) {
-			defer view.SetReadOnlyErr(origViewReadOnlyErr)
+		if postUnsealFunc != nil {
+			c.postUnsealFuncs = append(c.postUnsealFuncs, postUnsealFunc)
 		}
-
-		// Initialize the backend
-		sysView := c.mountEntrySysView(entry)
-
-		var backend logical.Backend
-		backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
-		if err != nil {
-			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
-
-			if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
-				c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
-				goto ROUTER_MOUNT
-			}
-			return errLoadAuthFailed
-		}
-		if backend == nil {
-			return fmt.Errorf("nil backend returned from %q factory", entry.Type)
-		}
-
-		// update the entry running version with the configured version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			if entry.RunningSha256 == "" {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-			}
-		}
-
-		// Do not start up deprecated builtin plugins. If this is a major
-		// upgrade, stop unsealing and shutdown. If we've already mounted this
-		// plugin, skip backend initialization and mount the data for posterity.
-		if versions.IsBuiltinVersion(entry.RunningVersion) {
-			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
-			if c.isMajorVersionFirstMount(ctx) && err != nil {
-				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
-				return errLoadAuthFailed
-			} else if err != nil {
-				c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
-				backend.Cleanup(ctx)
-				backend = nil
-				goto ROUTER_MOUNT
-			}
-		}
-
-		{
-			// Check for the correct backend type
-			backendType := backend.Type()
-			if backendType != logical.TypeCredential {
-				return fmt.Errorf("cannot mount %q of type %q as an auth backend", entry.Type, backendType)
-			}
-		}
-
-	ROUTER_MOUNT:
-		// Mount the backend
-		path := credentialRoutePrefix + entry.Path
-		err = c.router.Mount(backend, path, entry, view)
-		if err != nil {
-			c.logger.Error("failed to mount auth entry", "path", entry.Path, "namespace", entry.Namespace(), "error", err)
-			return errLoadAuthFailed
-		}
-
-		if c.logger.IsInfo() {
-			c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace())
-		}
-
-		// Ensure the path is tainted if set in the mount table
-		if entry.Tainted {
-			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
-			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
-			path = entry.Namespace().Path + path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
-			c.router.Taint(ctx, path)
-		}
-
-		// Check if this is the token store
-		if entry.Type == mountTypeToken {
-			c.tokenStore = backend.(*TokenStore)
-
-			// At some point when this isn't beta we may persist this but for
-			// now always set it on mount
-			entry.Config.TokenType = logical.TokenTypeDefaultService
-
-			// this is loaded *after* the normal mounts, including cubbyhole
-			c.router.tokenStoreSaltFunc = c.tokenStore.Salt
-			c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, mountPathCubbyhole).(*CubbyholeBackend)
-		}
-
-		// Initialize
-		// Bind locally
-		localEntry := entry
-		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
-			if backend == nil {
-				postUnsealLogger.Error("skipping initialization for nil auth backend")
-				return
-			}
-			if !strutil.StrListContains(singletonMounts, localEntry.Type) {
-				view.SetReadOnlyErr(origViewReadOnlyErr)
-			}
-
-			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-			if err != nil {
-				postUnsealLogger.Error("failed to initialize auth backend", "error", err)
-			}
-		})
 	}
 
 	return nil
+}
+
+// setupCredentialsForNamespace is invoked after we've loaded the auth table
+// for a namespace to initialize the credential backends and setup the router
+func (c *Core) setupCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) ([]func(), error) {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	postUnsealFuncs := make([]func(), 0)
+
+	for _, entry := range c.auth.sortEntriesByPath().Entries {
+		// Only process entries with matching namespace ID
+		if entry.NamespaceID != ns.ID {
+			continue
+		}
+
+		postUnsealFunc, err := c.setupCredential(ctx, entry)
+		if err != nil {
+			return postUnsealFuncs, err
+		}
+
+		if postUnsealFunc != nil {
+			postUnsealFuncs = append(postUnsealFuncs, postUnsealFunc)
+		}
+	}
+
+	return postUnsealFuncs, nil
 }
 
 // teardownCredentials is used before we seal the vault to reset the credential
@@ -1212,10 +1363,28 @@ func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespac
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, false, predicate)
+		if err := c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, true, predicate); err != nil {
+			return err
+		}
+		if err := c.cleanupAuthEntriesLocked(ctx, authTable, false, predicate); err != nil {
+			return err
+		}
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from auth table", ns.Path))
+	}
+	return nil
+}
+
+// cleanupAuthEntriesLocked cleans up the auth entries matching the predicate, should only be called when authLock is locked
+func (c *Core) cleanupAuthEntriesLocked(ctx context.Context, mountTable *MountTable, updateStorage bool, predicate func(*MountEntry) bool) error {
+	for _, e := range mountTable.Entries {
+		if predicate(e) {
+			nsCtx := namespace.ContextWithNamespace(ctx, e.namespace)
+			if err := c.removeCredEntryLocked(nsCtx, e.Path, updateStorage); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -2449,8 +2449,18 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	// This is intentionally the last block in this function. We want to allow
 	// writes just before allowing client requests, to ensure everything has
 	// been set up properly before any writes can have happened.
-	//
-	// Use a small temporary worker pool to run postUnsealFuncs in parallel
+	c.runPostUnsealFuncs(c.postUnsealFuncs)
+
+	if api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
+		c.logger.Warn("disabling entities for local auth mounts through env var", "env", EnvVaultDisableLocalAuthMountEntities)
+	}
+	c.loginMFABackend.usedCodes = cache.New(0, 30*time.Second)
+	c.logger.Info("post-unseal setup complete")
+	return nil
+}
+
+// runPostUnsealFuncs uses a small temporary worker pool to run postUnsealFuncs in parallel
+func (c *Core) runPostUnsealFuncs(postUnsealFuncs []func()) {
 	postUnsealFuncConcurrency := runtime.NumCPU() * 2
 	if v := api.ReadBaoVariable("BAO_POSTUNSEAL_FUNC_CONCURRENCY"); v != "" {
 		pv, err := strconv.Atoi(v)
@@ -2462,7 +2472,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	}
 	if postUnsealFuncConcurrency <= 1 {
 		// Out of paranoia, keep the old logic for parallism=1
-		for _, v := range c.postUnsealFuncs {
+		for _, v := range postUnsealFuncs {
 			v()
 		}
 	} else {
@@ -2476,20 +2486,13 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 				}
 			}()
 		}
-		for _, v := range c.postUnsealFuncs {
+		for _, v := range postUnsealFuncs {
 			wg.Add(1)
 			jobs <- v
 		}
 		wg.Wait()
 		close(jobs)
 	}
-
-	if api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
-		c.logger.Warn("disabling entities for local auth mounts through env var", "env", EnvVaultDisableLocalAuthMountEntities)
-	}
-	c.loginMFABackend.usedCodes = cache.New(0, 30*time.Second)
-	c.logger.Info("post-unseal setup complete")
-	return nil
 }
 
 // preSeal is invoked before the barrier is sealed, allowing

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -427,7 +427,7 @@ func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
 			return nil, fmt.Errorf("namespace %q doesn't exist", name)
 		}
 
-		err = b.Core.sealManager.UnsealNamespace(ctx, ns, decodedKey)
+		err = b.Core.namespaceStore.UnsealNamespace(ctx, name, decodedKey)
 		if err != nil {
 			invalidKeyErr := &ErrInvalidKey{}
 			switch {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -944,6 +944,11 @@ func (c *Core) removeMountEntry(ctx context.Context, path string, updateStorage 
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
+	return c.removeMountEntryLocked(ctx, path, updateStorage)
+}
+
+// removeMountEntry should only be called when c.mountsLock is locked
+func (c *Core) removeMountEntryLocked(ctx context.Context, path string, updateStorage bool) error {
 	// Remove the entry from the mount table
 	newTable := c.mounts.shallowClone()
 	entry, err := newTable.remove(ctx, path)
@@ -1467,6 +1472,111 @@ func listTransactionalMountsForNamespace(ctx context.Context, barrier logical.St
 	return globalEntries, localEntries, nil
 }
 
+// loadMountsForNamespace is used to load the mounts of a namespace to the mount table
+func (c *Core) loadMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	// Check if we're on a non-transactional storage
+	if _, ok := c.barrier.(logical.TransactionalStorage); !ok {
+		return c.loadLegacyMountsForNamespace(ctx, ns)
+	}
+	return c.loadTransactionalMountsForNamespace(ctx, ns)
+}
+
+// loadLegacyMountsForNamespace is used to load the mounts of a namespace on a legacy single-entry format
+// from a non-transactional storage to the mount table
+func (c *Core) loadLegacyMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if ns == nil {
+		return fmt.Errorf("namespace is nil")
+	}
+
+	if c.IsNSSealed(ns) {
+		return fmt.Errorf("namespace is sealed")
+	}
+
+	view := c.NamespaceView(ns)
+
+	raw, err := view.Get(ctx, coreMountConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read legacy mount table", "error", err)
+		return errLoadMountsFailed
+	}
+	rawLocal, err := view.Get(ctx, coreLocalMountConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read legacy local mount table", "error", err)
+		return errLoadMountsFailed
+	}
+
+	if raw != nil {
+		mountTable, err := c.decodeMountTable(ctx, raw.Value)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
+			return err
+		}
+
+		if mountTable != nil {
+			c.mounts.Entries = append(c.mounts.Entries, mountTable.Entries...)
+		}
+	}
+
+	if rawLocal != nil {
+		localMountTable, err := c.decodeMountTable(ctx, rawLocal.Value)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
+			return err
+		}
+
+		if localMountTable != nil {
+			c.mounts.Entries = append(c.mounts.Entries, localMountTable.Entries...)
+		}
+	}
+
+	return nil
+}
+
+// loadTransactionalMountsForNamespace is used to load the mounts of a namespace on a transactional storage
+// to the mount table
+func (c *Core) loadTransactionalMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if ns == nil {
+		return fmt.Errorf("namespace is nil")
+	}
+
+	if c.IsNSSealed(ns) {
+		return fmt.Errorf("namespace is sealed")
+	}
+
+	view := c.NamespaceView(ns)
+	globalEntries, localEntries, err := listTransactionalMountsForNamespace(ctx, view)
+	if err != nil {
+		return fmt.Errorf("failed to list mounts for namespace: %w", err)
+	}
+
+	for index, uuid := range globalEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreMountConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading mount table entry (%v %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.mounts.Entries = append(c.mounts.Entries, entry)
+		}
+	}
+
+	for index, uuid := range localEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalMountConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading local mount table entry (%v %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.mounts.Entries = append(c.mounts.Entries, entry)
+		}
+	}
+
+	return nil
+}
+
 // This function reads the legacy, single-entry combined mount table,
 // returning true if it was used. This will let us know (if we're inside
 // a transaction) if we need to do an upgrade.
@@ -1880,6 +1990,121 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 	return nil
 }
 
+// setupMount is invoked on a mount entry to initialize the logical backends and setup the router
+func (c *Core) setupMount(ctx context.Context, entry *MountEntry) (func(), error) {
+	// Initialize the backend, special casing for system
+	view, err := c.mountEntryView(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	origReadOnlyErr := view.GetReadOnlyErr()
+
+	// Mark the view as read-only until the mounting is complete and
+	// ensure that it is reset after. This ensures that there will be no
+	// writes during the construction of the backend.
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	if strutil.StrListContains(singletonMounts, entry.Type) {
+		defer view.SetReadOnlyErr(origReadOnlyErr)
+	}
+
+	// Create the new backend
+	var backend logical.Backend
+	sysView := c.mountEntrySysView(entry)
+	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
+	if err != nil {
+		c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
+
+		if c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
+			c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
+			goto ROUTER_MOUNT
+		}
+		return nil, errLoadMountsFailed
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("created mount entry of type %q is nil", entry.Type)
+	}
+
+	// update the entry running version with the configured version, which was verified during registration.
+	entry.RunningVersion = entry.Version
+	if entry.RunningVersion == "" {
+		// don't set the running version to a builtin if it is running as an external plugin
+		if entry.RunningSha256 == "" {
+			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
+		}
+	}
+
+	// Do not start up deprecated builtin plugins. If this is a major
+	// upgrade, stop unsealing and shutdown. If we've already mounted this
+	// plugin, proceed with unsealing and skip backend initialization.
+	if versions.IsBuiltinVersion(entry.RunningVersion) {
+		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
+		if c.isMajorVersionFirstMount(ctx) && err != nil {
+			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+			return nil, errLoadMountsFailed
+		} else if err != nil {
+			c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
+			backend.Cleanup(ctx)
+			backend = nil
+			goto ROUTER_MOUNT
+		}
+	}
+
+	{
+		// Check for the correct backend type
+		backendType := backend.Type()
+
+		if backendType != logical.TypeLogical {
+			if err := knownMountType(entry.Type); err != nil {
+				return nil, err
+			}
+		}
+
+		c.setCoreBackend(entry, backend, view)
+	}
+
+ROUTER_MOUNT:
+	// Mount the backend
+	err = c.router.Mount(backend, entry.Path, entry, view)
+	if err != nil {
+		c.logger.Error("failed to mount entry", "path", entry.Path, "error", err)
+		return nil, errLoadMountsFailed
+	}
+
+	// Bind locally
+	localEntry := entry
+	postUnsealFunc := func() {
+		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
+		if backend == nil {
+			postUnsealLogger.Error("skipping initialization for nil backend", "path", localEntry.Path)
+			return
+		}
+		if !strutil.StrListContains(singletonMounts, localEntry.Type) {
+			view.SetReadOnlyErr(origReadOnlyErr)
+		}
+
+		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
+		if err != nil {
+			postUnsealLogger.Error("failed to initialize mount backend", "error", err)
+		}
+	}
+
+	if c.logger.IsInfo() {
+		c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace())
+	}
+
+	// Ensure the path is tainted if set in the mount table
+	if entry.Tainted {
+		// Calculate any namespace prefixes here, because when Taint() is called, there won't be
+		// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
+		path := entry.Namespace().Path + entry.Path
+		c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
+		c.router.Taint(ctx, path)
+	}
+
+	return postUnsealFunc, nil
+}
+
 // setupMounts is invoked after we've loaded the mount table to
 // initialize the logical backends and setup the router
 func (c *Core) setupMounts(ctx context.Context) error {
@@ -1887,117 +2112,44 @@ func (c *Core) setupMounts(ctx context.Context) error {
 	defer c.mountsLock.Unlock()
 
 	for _, entry := range c.mounts.sortEntriesByPathDepth().Entries {
-		// Initialize the backend, special casing for system
-		view, err := c.mountEntryView(entry)
+		postUnsealFunc, err := c.setupMount(ctx, entry)
 		if err != nil {
 			return err
 		}
 
-		origReadOnlyErr := view.GetReadOnlyErr()
-
-		// Mark the view as read-only until the mounting is complete and
-		// ensure that it is reset after. This ensures that there will be no
-		// writes during the construction of the backend.
-		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-		if strutil.StrListContains(singletonMounts, entry.Type) {
-			defer view.SetReadOnlyErr(origReadOnlyErr)
-		}
-
-		// Create the new backend
-		var backend logical.Backend
-		sysView := c.mountEntrySysView(entry)
-		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
-		if err != nil {
-			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
-
-			if c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
-				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
-				goto ROUTER_MOUNT
-			}
-			return errLoadMountsFailed
-		}
-		if backend == nil {
-			return fmt.Errorf("created mount entry of type %q is nil", entry.Type)
-		}
-
-		// update the entry running version with the configured version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			if entry.RunningSha256 == "" {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
-			}
-		}
-
-		// Do not start up deprecated builtin plugins. If this is a major
-		// upgrade, stop unsealing and shutdown. If we've already mounted this
-		// plugin, proceed with unsealing and skip backend initialization.
-		if versions.IsBuiltinVersion(entry.RunningVersion) {
-			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
-			if c.isMajorVersionFirstMount(ctx) && err != nil {
-				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
-				return errLoadMountsFailed
-			} else if err != nil {
-				c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
-				backend.Cleanup(ctx)
-				backend = nil
-				goto ROUTER_MOUNT
-			}
-		}
-
-		{
-			// Check for the correct backend type
-			backendType := backend.Type()
-
-			if backendType != logical.TypeLogical {
-				if err := knownMountType(entry.Type); err != nil {
-					return err
-				}
-			}
-
-			c.setCoreBackend(entry, backend, view)
-		}
-
-	ROUTER_MOUNT:
-		// Mount the backend
-		err = c.router.Mount(backend, entry.Path, entry, view)
-		if err != nil {
-			c.logger.Error("failed to mount entry", "path", entry.Path, "error", err)
-			return errLoadMountsFailed
-		}
-
-		// Bind locally
-		localEntry := entry
-		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
-			if backend == nil {
-				postUnsealLogger.Error("skipping initialization for nil backend", "path", localEntry.Path)
-				return
-			}
-			if !strutil.StrListContains(singletonMounts, localEntry.Type) {
-				view.SetReadOnlyErr(origReadOnlyErr)
-			}
-
-			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-			if err != nil {
-				postUnsealLogger.Error("failed to initialize mount backend", "error", err)
-			}
-		})
-
-		if c.logger.IsInfo() {
-			c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace())
-		}
-
-		// Ensure the path is tainted if set in the mount table
-		if entry.Tainted {
-			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
-			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
-			path := entry.Namespace().Path + entry.Path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
-			c.router.Taint(ctx, path)
+		if postUnsealFunc != nil {
+			c.postUnsealFuncs = append(c.postUnsealFuncs, postUnsealFunc)
 		}
 	}
+
 	return nil
+}
+
+// setupMountsForNamespace is invoked after we've loaded the mounts of a namespace to the mount table to
+// initialize the logical backends and setup the router
+func (c *Core) setupMountsForNamespace(ctx context.Context, ns *namespace.Namespace) ([]func(), error) {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	postUnsealFuncs := make([]func(), 0)
+
+	for _, entry := range c.mounts.sortEntriesByPath().Entries {
+		// Only process entries with matching namespace ID
+		if entry.NamespaceID != ns.ID {
+			continue
+		}
+
+		postUnsealFunc, err := c.setupMount(ctx, entry)
+		if err != nil {
+			return postUnsealFuncs, err
+		}
+
+		if postUnsealFunc != nil {
+			postUnsealFuncs = append(postUnsealFuncs, postUnsealFunc)
+		}
+	}
+
+	return postUnsealFuncs, nil
 }
 
 // unloadMounts is used before we seal the vault to reset the mounts to
@@ -2028,6 +2180,9 @@ func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespac
 		if err := c.cleanupMountBackends(ctx, mountTable, "", true, predicate); err != nil {
 			return err
 		}
+		if err := c.cleanupMountEntriesLocked(ctx, mountTable, false, predicate); err != nil {
+			return err
+		}
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from mount table", ns.Path))
@@ -2039,14 +2194,32 @@ func (c *Core) cleanupMountBackends(ctx context.Context, mountTable *MountTable,
 	for _, e := range mountTable.Entries {
 		if predicate(e) {
 			nsCtx := namespace.ContextWithNamespace(ctx, e.namespace)
+
+			// router.Unmount already calls backend.Cleanup so we're checking if we need to call Unmount first
+			if unmountRouter {
+				if err := c.router.Unmount(nsCtx, pathPrefix+e.Path); err != nil {
+					return err
+				}
+				continue
+			}
+
 			backend := c.router.MatchingBackend(nsCtx, pathPrefix+e.Path)
 			if backend != nil {
 				backend.Cleanup(ctx)
 			}
-			if unmountRouter {
-				if err := c.router.Unmount(nsCtx, e.Path); err != nil {
-					return err
-				}
+
+		}
+	}
+	return nil
+}
+
+// cleanupMountEntriesLocked cleans up the mount entries matching the predicate,should only be called when mountsLock is locked
+func (c *Core) cleanupMountEntriesLocked(ctx context.Context, mountTable *MountTable, updateStorage bool, predicate func(*MountEntry) bool) error {
+	for _, e := range mountTable.Entries {
+		if predicate(e) {
+			nsCtx := namespace.ContextWithNamespace(ctx, e.namespace)
+			if err := c.removeMountEntryLocked(nsCtx, e.Path, updateStorage); err != nil {
+				return err
 			}
 		}
 	}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -860,7 +860,12 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	}
 
 	ns.lock.Lock()
-	defer ns.lock.Unlock()
+	releaseNsLock := true
+	defer func() {
+		if releaseNsLock {
+			ns.lock.Unlock()
+		}
+	}()
 
 	namespaceToUnseal, err := ns.getNamespaceByPathLocked(ctx, path)
 	if err != nil {
@@ -868,14 +873,51 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	}
 
 	if namespaceToUnseal == nil {
-		return nil
+		return fmt.Errorf("namespace %q not found", path)
 	}
 
 	if namespaceToUnseal.ID == namespace.RootNamespaceID {
 		return errors.New("unable to unseal root namespace")
 	}
 
-	return ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal, key)
+	if err := ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal, key); err != nil {
+		return err
+	}
+	releaseNsLock = false
+	ns.lock.Unlock()
+
+	// If namespace is still sealed meaning we do not have enough shards yet, return early
+	if ns.core.IsNSSealed(namespaceToUnseal) {
+		return nil
+	}
+
+	// Then proceed to load mounts and credentials
+	if err := ns.core.loadMountsForNamespace(ctx, namespaceToUnseal); err != nil {
+		return err
+	}
+
+	postUnsealFuncs := make([]func(), 0)
+
+	if postUnsealMountFuncs, err := ns.core.setupMountsForNamespace(ctx, namespaceToUnseal); err != nil {
+		return err
+	} else {
+		postUnsealFuncs = append(postUnsealFuncs, postUnsealMountFuncs...)
+	}
+
+	if err := ns.core.loadCredentialsForNamespace(ctx, namespaceToUnseal); err != nil {
+		return err
+	}
+
+	if postUnsealCredFuncs, err := ns.core.setupCredentialsForNamespace(ctx, namespaceToUnseal); err != nil {
+		return err
+	} else {
+		postUnsealFuncs = append(postUnsealFuncs, postUnsealCredFuncs...)
+	}
+
+	// now we run the collected post unseal functions to finalize unsealing
+	ns.core.runPostUnsealFuncs(postUnsealFuncs)
+
+	return nil
 }
 
 // ResolveNamespaceFromRequest resolves a namespace from the 'X-Vault-Namespace'


### PR DESCRIPTION
- Clean up mount and auth table of the namespace when sealing
- Remount mount and auth table when namespace is unsealed
- Initialize remounted mount and auth table backends when namespace is unsealed

The diffs for mount.go and auth.go looks a bit much, but the main change is: the core logic of setupMounts/setupCredentials are extracted out to setupMount/setupCredential to be reused for namespaces in setupMountsForNamespaces/setupCredentialsForNamespaces. Both return the post seal funcs to be called instead of saving them in the core global core.postSealFuncs