### PR TITLE
Add CLI support for unsealing namespaces

### DIFF
--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -51,3 +51,20 @@ func (s *Sys) UnsealNamespaceWithContext(ctx context.Context, req *UnsealNamespa
 	err = resp.DecodeJSON(&result)
 	return result.Data, err
 }
+
+func (c *Sys) SealNamespace(name string) error {
+	return c.SealNamespaceWithContext(context.Background(), name)
+}
+
+func (c *Sys) SealNamespaceWithContext(ctx context.Context, name string) error {
+	r := c.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/namespaces/%s/seal", name))
+
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	_, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type UnsealNamespaceInput struct {
+	Path  string `json:"path"`
+	Key   string `json:"key"`
+	Reset bool   `json:"reset"`
+}
+
+type NamespaceSealStatusOutput struct {
+	Type        string `json:"type"`
+	Initialized bool   `json:"initialized"`
+	Sealed      bool   `json:"sealed"`
+	T           int    `json:"t"`
+	N           int    `json:"n"`
+	Progress    int    `json:"progress"`
+	Nonce       string `json:"nonce"`
+}
+
+func (s *Sys) UnsealNamespace(req *UnsealNamespaceInput) (*NamespaceSealStatusOutput, error) {
+	return s.UnsealNamespaceWithContext(context.Background(), req)
+}
+
+func (s *Sys) UnsealNamespaceWithContext(ctx context.Context, req *UnsealNamespaceInput) (*NamespaceSealStatusOutput, error) {
+	body := map[string]any{"key": req.Key, "reset": req.Reset}
+
+	r := s.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/namespaces/%s/unseal", req.Path))
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	ctx, cancelFunc := s.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	resp, err := s.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:errcheck // ignoring the error here as its only fulfilling the signature and not returning any sensible error
+	defer resp.Body.Close()
+
+	var result struct {
+		Data *NamespaceSealStatusOutput
+	}
+	err = resp.DecodeJSON(&result)
+	return result.Data, err
+}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/vault"
 	"github.com/openbao/openbao/vault/seal"
+	"github.com/stretchr/testify/require"
 
 	auditFile "github.com/openbao/openbao/builtin/audit/file"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
@@ -384,4 +385,44 @@ func testTokenAndAccessor(tb testing.TB, client *api.Client) (string, string) {
 		tb.Fatalf("missing auth data: %#v", secret)
 	}
 	return secret.Auth.ClientToken, secret.Auth.Accessor
+}
+
+// testVaultServerWithNamespace creates a test vault cluster (with an existing namespace
+// sealed or unsealed depending on the sealed flag provided to the function) and returns
+// a configured API client (with namespace header set), unseal keyshares and closer function.
+func testVaultServerWithNamespace(tb testing.TB, name string, sealed bool) (*api.Client, []string, func()) {
+	tb.Helper()
+
+	client, _, closer := testVaultServerUnseal(tb)
+	data := map[string]any{
+		"seal": map[string]any{
+			"type":             "shamir",
+			"secret_shares":    3,
+			"secret_threshold": 2,
+		},
+	}
+	resp, err := client.Logical().Write("/sys/namespaces/"+name, data)
+	require.NoError(tb, err)
+	keys, ok := resp.Data["key_shares"].([]any)
+	require.True(tb, ok)
+	keyShares := make([]string, 0, len(keys))
+	for _, share := range keys {
+		keyShares = append(keyShares, share.(string))
+	}
+	if sealed {
+		return client, keyShares, closer
+	}
+
+	for _, keyShare := range keyShares {
+		status, err := client.Sys().UnsealNamespace(&api.UnsealNamespaceInput{
+			Path: name,
+			Key:  keyShare,
+		})
+		require.NoError(tb, err)
+		if !status.Sealed {
+			break
+		}
+	}
+
+	return client, keyShares, closer
 }

--- a/command/commands.go
+++ b/command/commands.go
@@ -342,6 +342,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace unseal": func() (cli.Command, error) {
+			return &NamespaceUnsealCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"operator": func() (cli.Command, error) {
 			return &OperatorCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/commands.go
+++ b/command/commands.go
@@ -342,6 +342,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace seal": func() (cli.Command, error) {
+			return &NamespaceSealCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"namespace unseal": func() (cli.Command, error) {
 			return &NamespaceUnsealCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace.go
+++ b/command/namespace.go
@@ -59,6 +59,10 @@ Usage: bao namespace <subcommand> [options] [args]
 
       $ bao namespace unlock
 
+  Unseal the namespace:
+
+      $ bao namespace unseal
+
   Please see the individual subcommand help for detailed usage information.
 `
 

--- a/command/namespace.go
+++ b/command/namespace.go
@@ -59,6 +59,10 @@ Usage: bao namespace <subcommand> [options] [args]
 
       $ bao namespace unlock
 
+  Seal the namespace:  
+
+      $ bao namespace seal
+
   Unseal the namespace:
 
       $ bao namespace unseal

--- a/command/namespace_seal.go
+++ b/command/namespace_seal.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceSealCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceSealCommand)(nil)
+)
+
+type NamespaceSealCommand struct {
+	*BaseCommand
+}
+
+func (c *NamespaceSealCommand) Synopsis() string {
+	return "Seals the namespace"
+}
+
+func (c *NamespaceSealCommand) Help() string {
+	helpText := `
+Usage: bao namespace seal [options] PATH
+
+  Seals the OpenBao namespace. Sealing tells the namespace to stop responding
+  to any operations until it is unsealed. When sealed, the namespace
+  discards its in-memory root key used data encryption, so it is physically
+  blocked from responding to operations while sealed.
+
+  If an unseal is in progress, sealing the namespace will reset the unsealing
+  process. Users will have to re-enter their portions of the root key again.
+
+  This command does nothing if the namespace is already sealed.
+
+  Seal the namespace:
+
+      $ bao namespace seal
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceSealCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP)
+}
+
+func (c *NamespaceSealCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultNamespaces()
+}
+
+func (c *NamespaceSealCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceSealCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	namespacePath := strings.TrimSpace(args[0])
+	if err = client.Sys().SealNamespace(namespacePath); err != nil {
+		c.UI.Error(fmt.Sprintf("Error sealing: %s", err))
+		return 2
+	}
+
+	c.UI.Output(fmt.Sprintf("Success! Namespace %q is sealed.", namespacePath))
+	return 0
+}

--- a/command/namespace_seal_test.go
+++ b/command/namespace_seal_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func testNamespaceSealCommand(tb testing.TB) (*cli.MockUi, *NamespaceSealCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceSealCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceSealCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name   string
+		args   []string
+		out    string
+		code   int
+		sealed bool
+	}{
+		{
+			name:   "not enough arguments provided",
+			args:   []string{},
+			out:    "Not enough arguments",
+			code:   1,
+			sealed: false,
+		},
+		{
+			name:   "too many arguments provided",
+			args:   []string{"foo", "bar"},
+			out:    "Too many arguments",
+			code:   1,
+			sealed: false,
+		},
+		{
+			name:   "happy path",
+			args:   []string{nsName},
+			out:    `Success! Namespace "ns" is sealed.`,
+			code:   0,
+			sealed: true,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+				defer closer()
+
+				ui, cmd := testNamespaceSealCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+			})
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceSealCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_unseal.go
+++ b/command/namespace_unseal.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/go-secure-stdlib/password"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceUnsealCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceUnsealCommand)(nil)
+)
+
+type NamespaceUnsealCommand struct {
+	*BaseCommand
+
+	flagReset bool
+
+	testOutput io.Writer // for tests
+}
+
+func (c *NamespaceUnsealCommand) Synopsis() string {
+	return "Unseals the namespace"
+}
+
+func (c *NamespaceUnsealCommand) Help() string {
+	helpText := `
+Usage: bao namespace unseal [options] PATH [KEY]
+
+  Unseals the OpenBao namespace. Provide a portion of the root key to unseal
+  an OpenBao namespace. Namespaces cannot perform operations until they are
+  unsealed. This command accepts a portion of the root key (an "unseal key").
+
+  The unseal key can be supplied as an argument to the command, but this is
+  not recommended as the unseal key will be available in your history:
+
+      $ bao namespace unseal ns1 IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+
+  Instead, run the command with no arguments and it will prompt for the key:
+
+      $ bao namespace unseal ns1
+      Key (will be hidden): IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+
+  Optionally, you can reset the unseal progress, discarding any already
+  provided unseal keyshares with a reset flag:
+
+      $ bao namespace unseal --reset ns1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceUnsealCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:       "reset",
+		Aliases:    []string{},
+		Target:     &c.flagReset,
+		Default:    false,
+		EnvVar:     "",
+		Completion: complete.PredictNothing,
+		Usage:      "Discard any previously entered keys to the unseal process.",
+	})
+
+	return set
+}
+
+func (c *NamespaceUnsealCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultNamespaces()
+}
+
+func (c *NamespaceUnsealCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceUnsealCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	var unsealKey string
+	var namespacePath string
+
+	args = f.Args()
+	switch len(args) {
+	case 0:
+		c.UI.Error("Not enough arguments (expected 1-2, got 0)")
+		return 1
+	case 1:
+		// We will prompt for the unseal key later
+		namespacePath = strings.TrimSpace(args[0])
+	case 2:
+		namespacePath = strings.TrimSpace(args[0])
+		unsealKey = strings.TrimSpace(args[1])
+	default:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1-2, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	if c.flagReset {
+		status, err := client.Sys().UnsealNamespace(
+			&api.UnsealNamespaceInput{
+				Path:  namespacePath,
+				Reset: true,
+			},
+		)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error resetting unseal process: %s", err))
+			return 2
+		}
+		return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+			Type:        status.Type,
+			Initialized: status.Initialized,
+			Sealed:      status.Sealed,
+			T:           status.T,
+			N:           status.N,
+			Progress:    status.Progress,
+			Nonce:       status.Nonce,
+		}})
+	}
+
+	if unsealKey == "" {
+		if c.flagNonInteractive {
+			c.UI.Error(wrapAtLength("Refusing to read from stdin with -non-interactive specified; specify unseal key as an argument to this command"))
+			return 1
+		}
+
+		// Override the output
+		writer := (io.Writer)(os.Stdout)
+		if c.testOutput != nil {
+			writer = c.testOutput
+		}
+
+		_, _ = fmt.Fprintf(writer, "Unseal Key (will be hidden): ")
+		value, err := password.Read(os.Stdin)
+		_, _ = fmt.Fprintf(writer, "\n")
+		if err != nil {
+			c.UI.Error(wrapAtLength(fmt.Sprintf("An error occurred attempting to "+
+				"ask for an unseal key. The raw error message is shown below, but "+
+				"usually this is because you attempted to pipe a value into the "+
+				"unseal command or you are executing outside of a terminal (tty). "+
+				"You should run the unseal command from a terminal for maximum "+
+				"security. If this is not an option, the unseal key can be provided "+
+				"as the first argument to the unseal command. The raw error "+
+				"was:\n\n%s", err)))
+			return 1
+		}
+		unsealKey = strings.TrimSpace(value)
+	}
+
+	status, err := client.Sys().UnsealNamespace(
+		&api.UnsealNamespaceInput{
+			Path: namespacePath,
+			Key:  unsealKey,
+		},
+	)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error unsealing: %s", err))
+		return 2
+	}
+
+	return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+		Type:        status.Type,
+		Initialized: status.Initialized,
+		Sealed:      status.Sealed,
+		T:           status.T,
+		N:           status.N,
+		Progress:    status.Progress,
+		Nonce:       status.Nonce,
+	}})
+}

--- a/command/namespace_unseal_test.go
+++ b/command/namespace_unseal_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testNamespaceUnsealCommand(tb testing.TB) (*cli.MockUi, *NamespaceUnsealCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceUnsealCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceUnsealCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name   string
+		args   []string
+		out    string
+		code   int
+		sealed bool
+	}{
+		{
+			name:   "not interactive terminal refuse",
+			args:   []string{"-non-interactive", "test"},
+			out:    "Refusing to read from stdin",
+			code:   1,
+			sealed: true,
+		},
+		{
+			name:   "not enough arguments provided",
+			args:   []string{},
+			out:    "Not enough arguments",
+			code:   1,
+			sealed: true,
+		},
+		{
+			name:   "too many arguments provided",
+			args:   []string{"foo", "bar", "baz"},
+			out:    "Too many arguments",
+			code:   1,
+			sealed: true,
+		},
+	}
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, true)
+				defer closer()
+
+				ui, cmd := testNamespaceUnsealCommand(t)
+				cmd.client = client
+				cmd.testOutput = io.Discard
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+			})
+		}
+	})
+
+	t.Run("reset flag", func(t *testing.T) {
+		t.Parallel()
+
+		client, unsealShares, closer := testVaultServerWithNamespace(t, nsName, true)
+		defer closer()
+
+		// Enter an unseal key
+		status, err := client.Sys().UnsealNamespace(&api.UnsealNamespaceInput{Path: nsName, Key: unsealShares[0]})
+		require.NoError(t, err)
+		require.Equal(t, 1, status.Progress)
+
+		ui, cmd := testNamespaceUnsealCommand(t)
+		cmd.client = client
+		cmd.testOutput = io.Discard
+
+		// Reset and check output
+		code := cmd.Run([]string{"-reset", nsName})
+		require.Equalf(t, 0, code, "expected %d to be 0", code)
+
+		expected := "0/2"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		require.Containsf(t, combined, expected, "expected %q to contain %q", combined, expected)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		client, unsealShares, closer := testVaultServerWithNamespace(t, nsName, true)
+		defer closer()
+
+		for _, key := range unsealShares {
+			ui, cmd := testNamespaceUnsealCommand(t)
+			cmd.client = client
+			cmd.testOutput = io.Discard
+
+			// Reset and check output
+			code := cmd.Run([]string{nsName, key})
+			require.Equalf(t, 0, code, "expected %d to be 0: %s", code, ui.ErrorWriter.String())
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceUnsealCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}
+
+func TestNamespaceUnsealCommand_Format(t *testing.T) {
+	defer func() {
+		require.NoError(t, os.Setenv(EnvVaultCLINoColor, ""))
+	}()
+
+	nsName := "ns"
+	client, unsealShares, closer := testVaultServerWithNamespace(t, nsName, true)
+	defer closer()
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	runOpts := &RunOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+		Client: client,
+	}
+
+	args, format, _, _, _ := setupEnv([]string{"namespace", "unseal", "-format", "json", "ns"})
+	require.Equal(t, "json", format)
+
+	// Unseal with one key
+	code := RunCustom(append(args, []string{unsealShares[0]}...), runOpts)
+	assert.Equalf(t, 0, code, "expected %d to be 0: %s", code, stderr.String())
+	assert.True(t, json.Valid(stdout.Bytes()), "expected output to be valid JSON")
+}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [ ] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [ ] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
