### PR TITLE
Switch API client to use /sys/generate-root-token endpoint

### DIFF
--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -17,18 +17,29 @@ func (c *Sys) GenerateRecoveryOperationTokenStatus() (*GenerateRootStatusRespons
 }
 
 func (c *Sys) GenerateRootStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommonWithContext(ctx, "/v1/sys/generate-root/attempt")
-}
-
-func (c *Sys) GenerateRecoveryOperationTokenStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommonWithContext(ctx, "/v1/sys/generate-recovery-token/attempt")
-}
-
-func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, path)
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/generate-root-token/attempt")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data GenerateRootStatusResponse `json:"data"`
+	}
+	err = resp.DecodeJSON(&result)
+	return &result.Data, err
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/generate-recovery-token/attempt")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -50,14 +61,6 @@ func (c *Sys) GenerateRecoveryOperationTokenInit(otp, pgpKey string) (*GenerateR
 }
 
 func (c *Sys) GenerateRootInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommonWithContext(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
-}
-
-func (c *Sys) GenerateRecoveryOperationTokenInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommonWithContext(ctx, "/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
-}
-
-func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -66,7 +69,34 @@ func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, 
 		"pgp_key": pgpKey,
 	}
 
-	r := c.c.NewRequest(http.MethodPut, path)
+	r := c.c.NewRequest(http.MethodPut, "/v1/sys/generate-root-token/attempt")
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data GenerateRootStatusResponse `json:"data"`
+	}
+	err = resp.DecodeJSON(&result)
+	return &result.Data, err
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	body := map[string]interface{}{
+		"otp":     otp,
+		"pgp_key": pgpKey,
+	}
+
+	r := c.c.NewRequest(http.MethodPut, "/v1/sys/generate-recovery-token/attempt")
 	if err := r.SetJSONBody(body); err != nil {
 		return nil, err
 	}
@@ -91,7 +121,7 @@ func (c *Sys) GenerateRecoveryOperationTokenCancel() error {
 }
 
 func (c *Sys) GenerateRootCancelWithContext(ctx context.Context) error {
-	return c.generateRootCancelCommonWithContext(ctx, "/v1/sys/generate-root/attempt")
+	return c.generateRootCancelCommonWithContext(ctx, "/v1/sys/generate-root-token/attempt")
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenCancelWithContext(ctx context.Context) error {
@@ -120,14 +150,6 @@ func (c *Sys) GenerateRecoveryOperationTokenUpdate(shard, nonce string) (*Genera
 }
 
 func (c *Sys) GenerateRootUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommonWithContext(ctx, "/v1/sys/generate-root/update", shard, nonce)
-}
-
-func (c *Sys) GenerateRecoveryOperationTokenUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommonWithContext(ctx, "/v1/sys/generate-recovery-token/update", shard, nonce)
-}
-
-func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -136,7 +158,34 @@ func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, sha
 		"nonce": nonce,
 	}
 
-	r := c.c.NewRequest(http.MethodPut, path)
+	r := c.c.NewRequest(http.MethodPut, "/v1/sys/generate-root-token/update")
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data GenerateRootStatusResponse `json:"Data"`
+	}
+	err = resp.DecodeJSON(&result)
+	return &result.Data, err
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	body := map[string]interface{}{
+		"key":   shard,
+		"nonce": nonce,
+	}
+
+	r := c.c.NewRequest(http.MethodPut, "/v1/sys/generate-recovery-token/update")
 	if err := r.SetJSONBody(body); err != nil {
 		return nil, err
 	}

--- a/changelog/3190.txt
+++ b/changelog/3190.txt
@@ -1,0 +1,8 @@
+```release-note:change
+api: `(*Sys).GenerateRoot*` methods now use the authenticated `/sys/generate-root-token` endpoints instead of the deprecated `/sys/generate-root` endpoints
+```
+
+```release-note:change
+command: `operator generate-root` now uses the authenticated `/sys/generate-root-token` endpoints instead of the deprecated `/sys/generate-root` endpoints
+
+```

--- a/command/operator_rotate_keys_test.go
+++ b/command/operator_rotate_keys_test.go
@@ -467,6 +467,7 @@ func TestOperatorRotateKeysCommand_Run(t *testing.T) {
 
 		genRoot, err := client.Sys().GenerateRootInit(otp, "")
 		require.NoError(t, err)
+		require.NotEmpty(t, genRoot.Nonce)
 
 		r, err := client.Sys().GenerateRootUpdate(recoveryKey, genRoot.Nonce)
 		require.NoError(t, err)

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -97,7 +97,7 @@ func GenerateRootWithError(t testing.T, cluster *vault.TestCluster, kind Generat
 		}
 	}
 	if !status.Complete {
-		return "", errors.New("generate root operation did not end successfully")
+		return "", fmt.Errorf("generate root operation did not end successfully: %d / %d", status.Progress, status.Required)
 	}
 
 	tokenBytes, err := base64.RawStdEncoding.DecodeString(status.EncodedToken)

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -116,6 +116,10 @@ func (c *Core) GenerateRootProgress(ctx context.Context) (int, error) {
 	}
 	defer unlock()
 
+	return c.lockedGenerateRootProgress(ctx)
+}
+
+func (c *Core) lockedGenerateRootProgress(ctx context.Context) (int, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return 0, err
@@ -140,6 +144,10 @@ func (c *Core) GenerateRootConfiguration(ctx context.Context) (*GenerateRootConf
 	}
 	defer unlock()
 
+	return c.lockedGenerateRootConfiguration(ctx)
+}
+
+func (c *Core) lockedGenerateRootConfiguration(ctx context.Context) (*GenerateRootConfig, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -168,6 +176,10 @@ func (c *Core) GenerateRootInit(ctx context.Context, otp, pgpKey string, strateg
 	}
 	defer unlock()
 
+	return c.lockedGenerateRootInit(ctx, otp, pgpKey, strategy)
+}
+
+func (c *Core) lockedGenerateRootInit(ctx context.Context, otp, pgpKey string, strategy GenerateRootStrategy) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -256,6 +268,10 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 	}
 	defer unlock()
 
+	return c.lockedGenerateRootUpdate(ctx, key, nonce, strategy)
+}
+
+func (c *Core) lockedGenerateRootUpdate(ctx context.Context, key []byte, nonce string, strategy GenerateRootStrategy) (*GenerateRootResult, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -407,6 +423,10 @@ func (c *Core) GenerateRootCancel(ctx context.Context) error {
 	}
 	defer unlock()
 
+	return c.lockedGenerateRootCancel(ctx)
+}
+
+func (c *Core) lockedGenerateRootCancel(ctx context.Context) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err

--- a/vault/logical_system_generate_root.go
+++ b/vault/logical_system_generate_root.go
@@ -41,8 +41,9 @@ func (b *SystemBackend) generateRootPaths() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Summary:  "Read the status of root token generation.",
-					Callback: b.handleGenerateRootStatus(),
+					Summary:                   "Read the status of root token generation.",
+					Callback:                  b.handleGenerateRootStatus(),
+					ForwardPerformanceStandby: true,
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: http.StatusText(http.StatusOK),
@@ -83,9 +84,10 @@ func (b *SystemBackend) generateRootPaths() []*framework.Path {
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Summary:     "Initialize root token generation.",
-					Description: "Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.",
-					Callback:    b.handleGenerateRootInit(),
+					Summary:                   "Initialize root token generation.",
+					Description:               "Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.",
+					Callback:                  b.handleGenerateRootInit(),
+					ForwardPerformanceStandby: true,
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: http.StatusText(http.StatusOK),
@@ -126,8 +128,9 @@ func (b *SystemBackend) generateRootPaths() []*framework.Path {
 					},
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Summary:  "Cancel root token generation.",
-					Callback: b.handleGenerateRootCancel(),
+					Summary:                   "Cancel root token generation.",
+					Callback:                  b.handleGenerateRootCancel(),
+					ForwardPerformanceStandby: true,
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: http.StatusText(http.StatusNoContent),
@@ -159,9 +162,10 @@ func (b *SystemBackend) generateRootPaths() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Summary:     "Provide an unseal key share for root token generation.",
-					Description: "If the threshold number of unseal key shares is reached, OpenBao will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.",
-					Callback:    b.handleGenerateRootUpdate(),
+					Summary:                   "Provide an unseal key share for root token generation.",
+					Description:               "If the threshold number of unseal key shares is reached, OpenBao will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.",
+					Callback:                  b.handleGenerateRootUpdate(),
+					ForwardPerformanceStandby: true,
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: http.StatusText(http.StatusOK),

--- a/vault/logical_system_generate_root.go
+++ b/vault/logical_system_generate_root.go
@@ -267,7 +267,8 @@ func (b *SystemBackend) handleGenerateRootInit() framework.OperationFunc {
 			}
 		}
 
-		if err := b.Core.GenerateRootInit(ctx, otp, pgpKey, GenerateStandardRootTokenStrategy); err != nil {
+		// expecting state lock to already be held by switchedLockHandleRequest
+		if err := b.Core.lockedGenerateRootInit(ctx, otp, pgpKey, GenerateStandardRootTokenStrategy); err != nil {
 			return handleError(err)
 		}
 
@@ -313,7 +314,8 @@ func (b *SystemBackend) handleGenerateRootUpdate() framework.OperationFunc {
 			}
 		}
 
-		result, err := b.Core.GenerateRootUpdate(ctx, decodedKey, nonce, GenerateStandardRootTokenStrategy)
+		// expecting state lock to already be held by switchedLockHandleRequest
+		result, err := b.Core.lockedGenerateRootUpdate(ctx, decodedKey, nonce, GenerateStandardRootTokenStrategy)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +334,8 @@ func (b *SystemBackend) handleGenerateRootUpdate() framework.OperationFunc {
 
 func (b *SystemBackend) handleGenerateRootCancel() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-		if err := b.Core.GenerateRootCancel(ctx); err != nil {
+		// expecting state lock to already be held by switchedLockHandleRequest
+		if err := b.Core.lockedGenerateRootCancel(ctx); err != nil {
 			return handleError(err)
 		}
 
@@ -382,7 +385,8 @@ func (b *SystemBackend) generateRootStatus(ctx context.Context, otp string) (*lo
 		}
 	}
 
-	generationConfig, err := b.Core.GenerateRootConfiguration(ctx)
+	// expecting state lock to already be held by switchedLockHandleRequest
+	generationConfig, err := b.Core.lockedGenerateRootConfiguration(ctx)
 	switch {
 	// Return the progress as 0 in this case, root generation has not started.
 	case errors.Is(err, ErrNoRootGeneration):
@@ -390,7 +394,8 @@ func (b *SystemBackend) generateRootStatus(ctx context.Context, otp string) (*lo
 		return handleError(err)
 	}
 
-	progress, err := b.Core.GenerateRootProgress(ctx)
+	// expecting state lock to already be held by switchedLockHandleRequest
+	progress, err := b.Core.lockedGenerateRootProgress(ctx)
 	if err != nil {
 		return handleError(err)
 	}


### PR DESCRIPTION
instead of deprecated /sys/generate-root

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [ ] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [ ] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
