### PR TITLE
Added API to provision Configmaps usable for KMS plugins

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1126,6 +1126,10 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
+	coreConfig.SealWrapperFactory = func(ctx context.Context, sealType string, cfg map[string]string) (wrapping.Wrapper, error) {
+		w, _, err := kms.ConfigureWrapper(ctx, sealType, wrapping.WithConfigMap(cfg))
+		return w, err
+	}
 	if c.flagDevThreeNode {
 		return c.enableThreeNodeDevCluster(&coreConfig, info, infoKeys, api.ReadBaoVariable("BAO_DEV_TEMP_DIR"))
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -240,6 +240,11 @@ type Core struct {
 	// seal is our seal, for seal configuration information
 	seal Seal
 
+	// sealWrapperFactory builds a wrapping.Wrapper from a KMS type name and
+	// config map. Injected at startup by the command layer via CoreConfig so
+	// that the SealManager can create namespace KMS seals at runtime.
+	sealWrapperFactory func(ctx context.Context, sealType string, config map[string]string) (wrapping.Wrapper, error)
+
 	// raftJoinDoneCh is used by the raft retry join routine to inform unseal process
 	// that the join is complete
 	raftJoinDoneCh chan struct{}
@@ -679,6 +684,11 @@ type CoreConfig struct {
 	// shamir seal.  In migration scenarios this is the new seal.
 	Seal Seal
 
+	// SealWrapperFactory creates a wrapping.Wrapper for a given KMS type and
+	// configuration map. Injected by the command layer (which owns the plugin
+	// catalog). If nil, non-Shamir namespace seals cannot be created.
+	SealWrapperFactory func(ctx context.Context, sealType string, config map[string]string) (wrapping.Wrapper, error)
+
 	// Unwrap seal is the optional seal marked "disabled"; this is the old
 	// seal in migration scenarios.
 	UnwrapSeal Seal
@@ -1022,6 +1032,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		c.seal = NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 	}
 	c.seal.SetCore(c)
+	c.sealWrapperFactory = conf.SealWrapperFactory
 
 	// Create the invalidation manager.
 	c.NewInvalidationManager()

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -374,30 +374,34 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 				return nil, errors.New("seal config must contain exactly one seal stanza")
 			}
 			kms := kmses[0]
-			if kms.Type != "shamir" {
-				return nil, errors.New("namespaces currently only support shamir seals")
-			}
 
 			sealConfig = &SealConfig{
 				Type: kms.Type,
 			}
 
-			if val, ok := kms.Config["shares"]; ok {
-				shares, err := parseutil.ParseInt(val)
-				if err != nil {
-					return nil, errors.New("value of shares parameter must be integer")
+			if kms.Type == "shamir" || kms.Type == "" {
+				// Shamir-specific fields: shares and threshold from the config map.
+				if val, ok := kms.Config["shares"]; ok {
+					shares, err := parseutil.ParseInt(val)
+					if err != nil {
+						return nil, errors.New("value of shares parameter must be integer")
+					}
+					sealConfig.SecretShares = int(shares)
 				}
-				sealConfig.SecretShares = int(shares)
-			}
-			if val, ok := kms.Config["threshold"]; ok {
-				threshold, err := parseutil.ParseInt(val)
-				if err != nil {
-					return nil, errors.New("value of shares parameter must be integer")
+				if val, ok := kms.Config["threshold"]; ok {
+					threshold, err := parseutil.ParseInt(val)
+					if err != nil {
+						return nil, errors.New("value of threshold parameter must be integer")
+					}
+					sealConfig.SecretThreshold = int(threshold)
 				}
-				sealConfig.SecretThreshold = int(threshold)
-			}
-			if pgpkeys, ok := data.GetOk("pgp_keys"); ok {
-				sealConfig.PGPKeys = pgpkeys.([]string)
+				if pgpkeys, ok := data.GetOk("pgp_keys"); ok {
+					sealConfig.PGPKeys = pgpkeys.([]string)
+				}
+			} else {
+				// Non-Shamir (KMS) seal: the entire config map is provider-specific.
+				// Shares and threshold are not applicable.
+				sealConfig.KMSConfig = kms.Config
 			}
 
 			if err := sealConfig.Validate(); err != nil {

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -525,6 +525,17 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 
 	var sealKeyShares [][]byte
 	if !exists {
+		// Unlock before SetSeal, InitializeBarrier, and initializeNamespace.
+		// Two reasons: (1) KMS wrappers (e.g. transit) call back into this
+		// server during SetConfig to validate the key (an Encrypt round-trip),
+		// and (2) initializeNamespace makes internal requests that also pass
+		// through ResolveNamespaceFromRequest. Both paths need ns.lock.RLock;
+		// holding ns.lock.Lock() here would deadlock them.
+		// The entry is already in namespacesByPath/UUID and marked in
+		// creationDeletionMap, so concurrent creation attempts are rejected.
+		ns.lock.Unlock()
+		unlocked = true
+
 		if sealConfig != nil {
 			if err := ns.core.sealManager.SetSeal(ctx, sealConfig, entry, true); err != nil {
 				return nil, fmt.Errorf("failed to set namespace seal: %w", err)
@@ -535,10 +546,6 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 				return nil, fmt.Errorf("failed to initialize namespace barrier: %w", err)
 			}
 		}
-
-		// unlock before initializeNamespace since that will re-acquire the lock.
-		ns.lock.Unlock()
-		unlocked = true
 
 		// Create sys/, token/ mounts and policies for the new namespace.
 		if err := ns.initializeNamespace(ctx, entry); err != nil {
@@ -558,8 +565,13 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		return nil, fmt.Errorf("failed to persist namespace: %w", err)
 	}
 
-	// Seal the namespace, as we've finished the setup.
-	if sealConfig != nil {
+	// Seal the namespace after setup for Shamir types only. Shamir namespaces
+	// must be sealed at birth because key shares need to be distributed before
+	// the namespace can be unlocked. KMS (auto-seal) namespaces are already
+	// unsealed by InitializeBarrier and must remain open so they are
+	// immediately usable without operator intervention.
+	shamirSeal := sealConfig != nil && (sealConfig.Type == "" || sealConfig.Type == "shamir")
+	if shamirSeal {
 		if err := ns.sealNamespaceLocked(ctx, entry); err != nil {
 			return nil, fmt.Errorf("failed to seal namespace: %w", err)
 		}

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -316,6 +316,12 @@ type SealConfig struct {
 
 	// Stores the progress of the verification operation (key shares)
 	VerificationProgress [][]byte `json:"-"`
+
+	// KMSConfig holds provider-specific configuration for non-Shamir seal
+	// types (e.g. transit, awskms). Stored as part of the seal config and
+	// encrypted at rest by the parent namespace's barrier, so it is readable
+	// without opening the child barrier. Not used for Shamir seals.
+	KMSConfig map[string]string `json:"kms_config,omitempty" mapstructure:"kms_config"`
 }
 
 // baseValidate is used as a shared base between `Validate` and `ValidateRecovery`
@@ -351,8 +357,13 @@ func (s *SealConfig) baseValidate() error {
 	return nil
 }
 
-// Validate is used to sanity check the (barrier) seal configuration
+// Validate is used to sanity check the (barrier) seal configuration.
+// Non-Shamir seals skip the share/threshold checks; those fields are
+// unused when a KMS wrapper handles key storage.
 func (s *SealConfig) Validate() error {
+	if s.Type != "" && s.Type != "shamir" {
+		return nil
+	}
 	if s.SecretShares < 1 {
 		return errors.New("shares must be at least one")
 	}

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -104,25 +104,55 @@ func (sm *SealManager) Reset() {
 // SetSeal creates a seal with provided config and sets it as provided namespace seal;
 // Initializes seal, creating security barrier and persisting seal config.
 func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *namespace.Namespace, writeToStorage bool) error {
-	sm.lock.Lock()
-	defer sm.lock.Unlock()
-
-	// Check if we have the seal present; if so, don't set any seal
-	// information as we don't want to overwrite what we have.
-	if _, ok := sm.sealByNamespace[ns.UUID]; ok {
-		return nil
-	}
-
+	// Validate and build the seal before acquiring the write lock. KMS wrappers
+	// (e.g. transit) call Encrypt during SetConfig to validate the key, which
+	// re-enters this server and needs sm.lock.RLock for the namespace barrier
+	// lookup. Holding sm.lock.Lock() here would produce a deadlock.
 	if err := sealConfig.Validate(); err != nil {
 		return fmt.Errorf("invalid seal configuration: %w", err)
 	}
 
-	metaPrefix := NamespaceStoragePathPrefix(ns)
+	// Fast idempotence check under read lock so we skip the expensive wrapper
+	// creation when the namespace seal is already registered.
+	sm.lock.RLock()
+	_, alreadySet := sm.sealByNamespace[ns.UUID]
+	sm.lock.RUnlock()
+	if alreadySet {
+		return nil
+	}
 
-	// Seal type would depend on the provided arguments
-	defaultSeal := NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
-	defaultSeal.SetCore(sm.core)
-	defaultSeal.SetMetaPrefix(metaPrefix)
+	var nsSeal Seal
+	if sealConfig.Type != "" && sealConfig.Type != "shamir" {
+		if sm.core.sealWrapperFactory == nil {
+			return fmt.Errorf("cannot create %q namespace seal: no KMS wrapper factory available", sealConfig.Type)
+		}
+		wrapper, err := sm.core.sealWrapperFactory(ctx, sealConfig.Type, sealConfig.KMSConfig)
+		if err != nil {
+			return fmt.Errorf("failed to configure %q seal for namespace %q: %w", sealConfig.Type, ns.Path, err)
+		}
+		autoSeal, err := NewAutoSeal(vaultseal.NewAccess(wrapper))
+		if err != nil {
+			return fmt.Errorf("failed to create auto-seal for namespace %q: %w", ns.Path, err)
+		}
+		nsSeal = autoSeal
+	} else {
+		nsSeal = NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
+	}
+
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	// Re-check under write lock: a concurrent call may have registered this
+	// namespace's seal between the read-lock check above and now. Finalize the
+	// seal we just built so its resources (e.g. KMS HTTP client) are released.
+	if _, ok := sm.sealByNamespace[ns.UUID]; ok {
+		_ = nsSeal.Finalize(ctx)
+		return nil
+	}
+
+	metaPrefix := NamespaceStoragePathPrefix(ns)
+	nsSeal.SetCore(sm.core)
+	nsSeal.SetMetaPrefix(metaPrefix)
 
 	// The configuration access should always at least use the parent's seal
 	// configuration information.
@@ -131,19 +161,19 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 		return fmt.Errorf("cannot seal the root namespace via this approach")
 	}
 	parentBarrier := sm.namespaceBarrierByLongestPrefix(parent)
-	defaultSeal.SetConfigAccess(parentBarrier)
+	nsSeal.SetConfigAccess(parentBarrier)
 
 	ctx = namespace.ContextWithNamespace(ctx, ns)
-	if err := defaultSeal.Init(ctx); err != nil {
+	if err := nsSeal.Init(ctx); err != nil {
 		return fmt.Errorf("error initializing seal: %w", err)
 	}
 
 	nsBarrier := barrier.NewAESGCMBarrier(sm.core.physical, ns)
 	sm.barrierByNamespacePath.Insert(ns.Path, nsBarrier)
-	sm.sealByNamespace[ns.UUID] = defaultSeal
+	sm.sealByNamespace[ns.UUID] = nsSeal
 
 	if writeToStorage {
-		if err := defaultSeal.SetBarrierConfig(ctx, sealConfig); err != nil {
+		if err := nsSeal.SetBarrierConfig(ctx, sealConfig); err != nil {
 			return fmt.Errorf("failed to set barrier config: %w", err)
 		}
 	}


### PR DESCRIPTION
## Description

As discussed, before of cleaning the KMS plugins from unsafe (non zero-trust) parameters taken from ENV string or random files, we need an API to provision the ConfigMap itself. 

The API keeps the backwards compatibility, so that people using openbao with API to create namespaces is safe to continue.

## Tested


Run against the shared dev-mode server

| Case | Scenario | Expected | Result |
|------|----------|----------|--------|
| A | `POST /v1/sys/namespaces/<name>` with no `seal` parameter | 200, namespace usable | OK |
| B | `seal "shamir" {}` — explicit Shamir type, no shares/threshold | 400 (Validate fires) | OK |
| C | `seal "shamir" { shares=1 threshold=1 }` | 200, response has `key_shares=1`, `key_threshold=1` | OK |
| D | `seal "shamir" { shares=5 threshold=3 }` | 200, response has `key_shares=5`, `key_threshold=3` | OK |
| E | Malformed HCL in `seal` field | 400/500 | OK |
| F | Two `seal` stanzas (API requires exactly one) | 400/500 | OK |
| G | Non-integer value for `shares` | 400/500 | OK |
| H | `threshold` > `shares` (`Validate()` must fire) | 400/500 | OK |
| H2 | `shares=0`, `threshold=0` | 400/500 | OK |
| I | Non-Shamir type must **not** return the old "namespaces currently only support shamir seals" error | Old gate gone; different error or 200 | OK |
| J | CLI: `bao namespace create` / `bao namespace delete` without seal | exit 0 | OK |
| K | `custom_metadata` field preserved alongside `seal` field | 200, metadata intact | OK |

Run against an isolated dev-mode server 

| Step | Scenario | Result |
|------|----------|--------|
| 1 | Enable transit secrets engine | OK |
| 2 | Create AES-256-GCM96 key `ns-seal-key` | OK |
| 3 | `POST /v1/sys/namespaces/kms-transit-ns` with transit KMS seal config; response must omit `key_shares`/`key_threshold` | OK |
| 4 | `LIST /v1/sys/namespaces` — `kms-transit-ns/` appears | OK |
| 5 | `GET /v1/sys/namespaces/kms-transit-ns` readable | OK |
| 6 | `GET /v1/sys/seal-status` (namespace-scoped) — barrier is unsealed | OK |
| 7 | Namespace already initialized by `InitializeBarrier`; explicit init call skipped | OK |
| 8 | After init, namespace remains unsealed (transit auto-unseal active) | OK |
| 9 | Mount KV engine in `kms-transit-ns`, write and read back a secret | OK |
| 10 | Plain (no-seal) namespace created alongside KMS namespace — no cross-contamination | OK |
| 11 | Secret written in `kms-transit-ns` is not accessible from `plain-ns` context | OK |





Resolves: #

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
